### PR TITLE
Prepare v0.0.2 license metadata release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
-Copyright (c) 2026 pkistudio
+Private Key Gadgets - browser tools for PKI key material
+
+Copyright (c) 2000-2026 pkistudio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.0.1
+Current version: 0.0.2
 
 ## Features
 
@@ -144,6 +144,10 @@ Run the TypeScript and production build checks:
 npm run check
 npm run build
 ```
+
+## License
+
+Private Key Gadgets is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Vendor Assets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Align the LICENSE file format with pkistudio/pkistudiojs.
- Add a README License section pointing to the MIT license.
- Set project version metadata to 0.0.2 while keeping the package private.

## Verification
- npm run check
- npm run build

Fixes #3