### PR TITLE
Release 0.0.3 with GitHub Pages deployment

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when: running the pvkgadgets issue-to-release workflow, including issue creation, branch work, PR, merge, tag, release, and Actions checks."
+description: "Use when: running the pvkgadgets issue-to-release workflow, including issue creation, branch work, PR, merge, tag, GitHub Release, GitHub Pages deployment, and Actions checks."
 name: "pvkgadgets release workflow"
 argument-hint: "[version|TBD] [#issue] <short feature or fix summary>"
 agent: "agent"
@@ -7,7 +7,7 @@ agent: "agent"
 
 # pvkgadgets Release Workflow
 
-Run the standard pvkgadgets release workflow from issue creation through GitHub Release publication.
+Run the standard pvkgadgets release workflow from issue creation through GitHub Release publication and GitHub Pages deployment.
 
 Expected invocation examples:
 
@@ -123,14 +123,21 @@ Derive these from the invocation when possible:
     - Create a GitHub Release named `vX.Y.Z` with release notes summarizing user-facing changes and referencing the issue.
     - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
 
-11. Confirm Final State
-    - Verify:
-      - PR is merged and closed.
-      - issue is closed as completed.
-      - tag exists on `main` HEAD.
-      - GitHub Release is published.
-      - relevant GitHub Actions completed or are still running.
-    - Final response must include issue, PR, release, tag, and any Actions status.
+11. Deploy GitHub Pages
+   - Confirm `.github/workflows/pages.yml` exists and deploys the Vite `dist` output to GitHub Pages.
+   - Confirm the Pages workflow is triggered by the release merge to `main`. If needed and the user has permission, trigger `Deploy GitHub Pages` manually with `workflow_dispatch`.
+   - Watch the Pages workflow until it succeeds, fails, or remains running long enough that it should be reported as pending.
+   - Confirm the deployed Pages URL from the `github-pages` environment or the workflow deployment output.
+   - If the workflow fails, report the failing job and log summary before stopping; do not publish extra tags or releases to retry.
+
+12. Confirm Final State
+   - Verify PR is merged and closed.
+   - Verify issue is closed as completed.
+   - Verify tag exists on `main` HEAD.
+   - Verify GitHub Release is published.
+   - Verify GitHub Pages deployment completed successfully or is clearly reported as pending/failed.
+   - Verify relevant GitHub Actions completed or are still running.
+   - Final response must include issue, PR, release, tag, Pages URL/deployment status, and any Actions status.
 
 ## Final Response Format
 
@@ -139,6 +146,7 @@ Keep the final response concise and include:
 - Issue link and state
 - PR link and merge state
 - Release link and tag
+- Pages URL and deployment status
 - Verification summary
 - Actions status
 - Any follow-up needed

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static files
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.0.2
+Current version: 0.0.3
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Private Key Gadgets</title>
-    <script src="/vendor/pkistudiojs/pkistudio-core.js" defer></script>
-    <script src="/vendor/pkistudiojs/pkistudio.js" data-pkistudio-auto-init="false" defer></script>
+    <script src="%BASE_URL%vendor/pkistudiojs/pkistudio-core.js" defer></script>
+    <script src="%BASE_URL%vendor/pkistudiojs/pkistudio.js" data-pkistudio-auto-init="false" defer></script>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,12 @@ type SaveFileHandle = {
 };
 
 declare global {
+  interface ImportMeta {
+    readonly env: {
+      readonly BASE_URL: string;
+    };
+  }
+
   interface Window {
     PkiStudio?: PkiStudioApi;
     PkiStudioCore?: PkiStudioCoreApi;
@@ -124,6 +130,8 @@ const KEY_ALGORITHM_CANDIDATES: KeyAlgorithmCandidate[] = [
   ...createNamedCurveCandidates('X25519', ['X25519'], ['deriveBits']),
   ...createNamedCurveCandidates('X448', ['X448'], ['deriveBits'])
 ];
+
+const APP_BASE_URL = import.meta.env.BASE_URL;
 
 const EMBEDDED_VIEWER_STYLES = `
 :host {
@@ -431,8 +439,8 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   viewer = window.PkiStudio.init({
     mount: '#viewerMount',
-    oidUrl: '/vendor/pkistudiojs/oids.json',
-    newWindowUrl: '/viewer.html'
+    oidUrl: `${APP_BASE_URL}vendor/pkistudiojs/oids.json`,
+    newWindowUrl: `${APP_BASE_URL}viewer.html`
   });
   logApi('pkistudiojs.init', `Viewer ${window.PkiStudio.version ?? '(unknown version)'} mounted.`);
   applyEmbeddedViewerStyles(viewer);

--- a/viewer.html
+++ b/viewer.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>PkiStudioJS Viewer</title>
-    <script src="/vendor/pkistudiojs/pkistudio-core.js" defer></script>
-    <script src="/vendor/pkistudiojs/pkistudio.js" defer></script>
+    <script src="%BASE_URL%vendor/pkistudiojs/pkistudio-core.js" defer></script>
+    <script src="%BASE_URL%vendor/pkistudiojs/pkistudio.js" defer></script>
   </head>
   <body>
     <div id="pkistudio"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: './',
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- Bump pvkgadgets to 0.0.3.
- Add a GitHub Pages deployment workflow for the Vite `dist` output.
- Make app, viewer, vendor asset, OID, and viewer-window URLs safe for GitHub Pages subpath hosting.
- Extend the release prompt so Pages deployment is part of the standard release workflow.

## Verification
- `npm run check`
- `npm run build`
- Confirmed built assets do not contain root-relative HTML/runtime references that would break under a Pages subpath.

Fixes #5