### PR TITLE
Enable GitHub Pages from deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload static files
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Set `enablement: true` on `actions/configure-pages` so the deployment workflow can initialize GitHub Pages when it has not been configured yet.

## Verification
- YAML diagnostics report no errors.
- This is intended to fix the failed Pages run: https://github.com/pkistudio/pvkgadgets/actions/runs/25276644253

Refs #5