### PR TITLE
Update embedded PkiStudioJS viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.0.4
+Current version: 0.0.5
 
 ## Features
 
@@ -107,7 +107,7 @@ Current version: 0.0.4
 - Embeds the vendored PkiStudioJS viewer directly in the right pane.
 - Displays the selected PrivateKey, PublicKey, Certificate, SubjectDN, or CSR DER object.
 - Keeps Viewer editing actions enabled only while a SubjectDN item is selected.
-- Disables the Viewer Load and Close actions, plus node Edit, Delete, Add, and Insert before actions, for read-only key material such as PrivateKey, PublicKey, Certificate, and CSR.
+- Disables the Viewer Load and Close actions, plus node Edit, Delete, Add, and Insert before actions, including the Insert before/Add submenus, for read-only key material such as PrivateKey, PublicKey, Certificate, and CSR.
 - Keeps the PkiStudioJS Save menu available for writing the currently displayed DER document to a file.
 - Opens PkiStudioJS new-window output in a viewer-only page.
 - Hides the standalone PkiStudioJS file picker in the embedded application shell.
@@ -151,7 +151,7 @@ Private Key Gadgets is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Vendor Assets
 
-The prototype vendors the PkiStudioJS browser assets under `public/vendor/pkistudiojs/`:
+The prototype vendors the PkiStudioJS 0.2.4 browser assets under `public/vendor/pkistudiojs/`:
 
 - `pkistudio-core.js`
 - `pkistudio.js`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Current version: 0.0.5
 ### Tree View
 
 - Displays key material in a PkiStudioJS-like tree with a menu area and message area.
+- Uses a PkiStudioJS-style tree card, connector lines, node icons, selection colors, and lower message area for the left pane.
 - Supports multiple top-level key pair items.
 - Supports child items for SubjectDN, PrivateKey, PublicKey, Certificate, and CSR objects.
 - Opens node menus from the tree item icon, matching the interaction style used by PkiStudioJS.
@@ -70,6 +71,11 @@ Current version: 0.0.5
 - Allows child items to be deleted from their icon menu.
 - Allows top-level key pair items to be deleted from their icon menu; deleting a key pair removes all child items as well.
 - Lets the left and right panes be resized with the splitter between them.
+
+### Application Shell
+
+- Fills the browser viewport and resizes the workspace, key tree, ASN.1 viewer, and API Log with the available browser area.
+- Shows an About menu in the top application bar with the current Private Key Gadgets version.
 
 ### SubjectDN Objects
 
@@ -109,7 +115,7 @@ Current version: 0.0.5
 - Keeps Viewer editing actions enabled only while a SubjectDN item is selected.
 - Disables the Viewer Load and Close actions, plus node Edit, Delete, Add, and Insert before actions, including the Insert before/Add submenus, for read-only key material such as PrivateKey, PublicKey, Certificate, and CSR.
 - Keeps the PkiStudioJS Save menu available for writing the currently displayed DER document to a file.
-- Opens PkiStudioJS new-window output in a viewer-only page.
+- Opens PkiStudioJS New Window output in a standalone viewer-only page instead of a new pvkgadgets application shell.
 - Hides the standalone PkiStudioJS file picker in the embedded application shell.
 
 ### API Log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/vendor/pkistudiojs/pkistudio.js
+++ b/public/vendor/pkistudiojs/pkistudio.js
@@ -2184,7 +2184,7 @@ details[open] > summary .node-line {
         return;
       }
     
-      const url = new URL(window.location.href);
+      const url = createNewWindowUrl();
       url.searchParams.set('expand', key);
       url.hash = '';
     
@@ -2213,7 +2213,7 @@ details[open] > summary .node-line {
         return;
       }
     
-      const url = new URL(window.location.href);
+      const url = createNewWindowUrl();
       url.searchParams.delete('expand');
       url.searchParams.set('subtree', key);
       url.hash = '';
@@ -2230,6 +2230,10 @@ details[open] > summary .node-line {
 
     function openViewerWindow(url) {
       return window.open(url.toString(), '_blank');
+    }
+
+    function createNewWindowUrl() {
+      return new URL(options.newWindowUrl || window.location.href, window.location.href);
     }
     
     async function writeClipboardText(text) {

--- a/public/vendor/pkistudiojs/pkistudio.js
+++ b/public/vendor/pkistudiojs/pkistudio.js
@@ -1,6 +1,6 @@
 (() => {
   let defaultInstance = null;
-  const APP_VERSION = '0.2.2';
+  const APP_VERSION = '0.2.4';
 
   const APP_STYLES = `:host {
   color-scheme: light;
@@ -30,17 +30,31 @@
 :host {
   display: block;
   margin: 0;
-  min-height: 100vh;
+  width: 100%;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
   font-family: Tahoma, "MS UI Gothic", "Yu Gothic UI", system-ui, sans-serif;
   font-size: 13px;
   color: var(--text);
   background: linear-gradient(#f7f9fc, var(--bg));
 }
 
+:host([data-pkistudio-fullscreen]) {
+  position: fixed;
+  inset: 0;
+  width: auto;
+  height: auto;
+}
+
 main {
-  width: min(1220px, calc(100% - 24px));
-  margin: 0 auto;
-  padding: 14px 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .menu {
@@ -54,7 +68,7 @@ main {
   margin-bottom: 0;
   border: 1px solid var(--panel-border);
   border-bottom: 0;
-  border-radius: 6px 6px 0 0;
+  border-radius: 0;
   padding: 4px;
   background: linear-gradient(#ffffff, var(--chrome));
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
@@ -135,11 +149,20 @@ p {
 }
 
 .card {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  min-height: 0;
   border: 1px solid var(--panel-border);
-  border-radius: 0 0 6px 6px;
-  padding: 8px;
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  padding: 6px;
   background: var(--window);
-  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: none;
+  overflow: hidden;
 }
 
 input[type="file"] {
@@ -151,8 +174,13 @@ input[type="file"] {
 }
 
 .viewer {
-  min-height: 560px;
-  max-height: calc(100vh - 150px);
+  flex: 1 1 auto;
+  width: 100%;
+  height: auto;
+  min-width: min(320px, 100%);
+  min-height: 0;
+  max-width: 100%;
+  max-height: none;
   overflow: auto;
   border: 1px solid var(--panel-border);
   border-radius: 3px;
@@ -422,7 +450,9 @@ details[open] > summary .node-line {
 }
 
 .notice {
-  margin-top: 8px;
+  flex: 0 0 auto;
+  margin-top: 0;
+  width: 100%;
   font-size: 12px;
 }
 
@@ -872,8 +902,20 @@ details[open] > summary .node-line {
 
 <div id="nodeContextMenu" class="node-context-menu" role="menu" hidden>
   <button type="button" role="menuitem" data-node-action="edit">Edit</button>
-  <button type="button" role="menuitem" data-node-action="insert-before">Insert before</button>
-  <button type="button" role="menuitem" data-node-action="add-child">Add</button>
+  <div class="context-menu-group" role="none">
+    <button type="button" class="context-submenu-trigger" role="menuitem" data-node-action="insert-before" aria-haspopup="menu" aria-expanded="false">Insert before</button>
+    <div class="node-context-submenu" role="menu" aria-label="Insert before">
+      <button type="button" role="menuitem" data-node-action="insert-before-new-item">New Item</button>
+      <button type="button" role="menuitem" data-node-action="insert-before-clipboard-hex">from Clipboard as HEX Text</button>
+    </div>
+  </div>
+  <div class="context-menu-group" role="none" data-add-menu>
+    <button type="button" class="context-submenu-trigger" role="menuitem" data-node-action="add-child" aria-haspopup="menu" aria-expanded="false">Add</button>
+    <div class="node-context-submenu" role="menu" aria-label="Add">
+      <button type="button" role="menuitem" data-node-action="add-child-new-item">New Item</button>
+      <button type="button" role="menuitem" data-node-action="add-child-clipboard-hex">from Clipboard as HEX Text</button>
+    </div>
+  </div>
   <button type="button" role="menuitem" data-node-action="delete">Delete</button>
   <div class="context-menu-group" role="none">
     <button type="button" class="context-submenu-trigger" role="menuitem" data-node-action="send-to" aria-haspopup="menu" aria-expanded="false">Send to</button>
@@ -1019,6 +1061,21 @@ details[open] > summary .node-line {
   </form>
 </div>
 
+<div id="clipboardInsertDialog" class="edit-dialog" hidden>
+  <form id="clipboardInsertForm" class="edit-panel octet-panel">
+    <p id="clipboardInsertTitle" class="edit-title">Insert from Clipboard HEX</p>
+    <label>
+      HEX text
+      <textarea id="clipboardInsertHex" spellcheck="false"></textarea>
+    </label>
+    <div id="clipboardInsertError" class="edit-error" role="alert"></div>
+    <div class="edit-actions">
+      <button id="clipboardInsertSubmit" type="submit">Insert</button>
+      <button type="button" data-clipboard-insert-action="cancel">Cancel</button>
+    </div>
+  </form>
+</div>
+
 <div id="aboutDialog" class="edit-dialog" hidden>
   <section class="edit-panel about-panel" role="dialog" aria-labelledby="aboutTitle" aria-modal="true">
     <p id="aboutTitle" class="about-name">PkiStudioJS</p>
@@ -1046,6 +1103,10 @@ details[open] > summary .node-line {
 
   function createAppRoot(mount, options) {
     const useShadowRoot = options.shadowRoot !== false && typeof mount.attachShadow === 'function';
+    if (options.fullscreen && !(mount instanceof ShadowRoot)) {
+      applyFullscreenPageStyles();
+      mount.setAttribute('data-pkistudio-fullscreen', '');
+    }
     const root = mount instanceof ShadowRoot
       ? mount
       : useShadowRoot
@@ -1054,6 +1115,15 @@ details[open] > summary .node-line {
 
     root.innerHTML = `<style>${APP_STYLES}</style>${APP_MARKUP}`;
     return root;
+  }
+
+  function applyFullscreenPageStyles() {
+    document.documentElement.style.height = '100%';
+    document.documentElement.style.margin = '0';
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.height = '100%';
+    document.body.style.margin = '0';
+    document.body.style.overflow = 'hidden';
   }
 
   function init(options = {}) {
@@ -1100,6 +1170,12 @@ details[open] > summary .node-line {
     const octetHex = scope.querySelector('#octetHex');
     const octetFileInput = scope.querySelector('#octetFileInput');
     const octetError = scope.querySelector('#octetError');
+    const clipboardInsertDialog = scope.querySelector('#clipboardInsertDialog');
+    const clipboardInsertForm = scope.querySelector('#clipboardInsertForm');
+    const clipboardInsertTitle = scope.querySelector('#clipboardInsertTitle');
+    const clipboardInsertHex = scope.querySelector('#clipboardInsertHex');
+    const clipboardInsertError = scope.querySelector('#clipboardInsertError');
+    const clipboardInsertSubmit = scope.querySelector('#clipboardInsertSubmit');
     const aboutDialog = scope.querySelector('#aboutDialog');
     
     const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
@@ -1136,6 +1212,8 @@ details[open] > summary .node-line {
     let activeEditNodeId = null;
     let activeTimeNodeId = null;
     let activeOctetNodeId = null;
+    let activeClipboardInsertNodeId = null;
+    let activeClipboardInsertMode = 'insert-before';
     let nextNodeId = 1;
     
     async function loadOidNames() {
@@ -2110,7 +2188,7 @@ details[open] > summary .node-line {
       url.searchParams.set('expand', key);
       url.hash = '';
     
-      const expandedWindow = window.open(url.toString(), '_blank');
+      const expandedWindow = openViewerWindow(url);
       if (!expandedWindow) {
         localStorage.removeItem(key);
         fileNotice.textContent = 'The encapsulated DER could not be opened because the popup was blocked.';
@@ -2140,7 +2218,7 @@ details[open] > summary .node-line {
       url.searchParams.set('subtree', key);
       url.hash = '';
     
-      const subtreeWindow = window.open(url.toString(), '_blank');
+      const subtreeWindow = openViewerWindow(url);
       if (!subtreeWindow) {
         localStorage.removeItem(key);
         fileNotice.textContent = 'The subtree could not be opened because the popup was blocked.';
@@ -2148,6 +2226,10 @@ details[open] > summary .node-line {
       }
     
       subtreeWindow.opener = null;
+    }
+
+    function openViewerWindow(url) {
+      return window.open(url.toString(), '_blank');
     }
     
     async function writeClipboardText(text) {
@@ -2320,20 +2402,74 @@ details[open] > summary .node-line {
       await writeClipboardText(treeText);
       fileNotice.textContent = `Copied tree text for ${getTagName(node)} (${treeText.split('\n').length} lines).`;
     }
+
+    function parseClipboardHexNode(text) {
+      const bytes = hexToBytes(text);
+      const nodes = parseElements(bytes, 0, bytes.length);
+      const encodedBytes = encodeNodes(nodes);
+      if (!bytesEqual(encodedBytes, bytes)) throw new Error('The clipboard HEX is not a canonical DER/BER node');
+      if (nodes.length !== 1) throw new Error('Clipboard HEX must contain exactly one ASN.1 element');
+
+      return nodes[0];
+    }
+
+    function insertHexTextBefore(targetNodeId, text) {
+      const targetNode = nodeById.get(targetNodeId);
+      if (!targetNode) throw new Error('The insertion point was not found');
+
+      const insertedNode = parseClipboardHexNode(text);
+      const insertedTagName = getTagName(insertedNode);
+      const targetTagName = getTagName(targetNode);
+      insertNodeBefore(targetNodeId, insertedNode);
+      fileNotice.textContent = `Inserted ${insertedTagName} from clipboard HEX before ${targetTagName}.`;
+    }
+
+    function addHexTextToNode(parentNodeId, text) {
+      const parentNode = nodeById.get(parentNodeId);
+      if (!parentNode) throw new Error('The parent node was not found');
+      if (!parentNode.constructed) throw new Error('Children can only be added to structured nodes');
+
+      const insertedNode = parseClipboardHexNode(text);
+      const insertedTagName = getTagName(insertedNode);
+      const parentTagName = getTagName(parentNode);
+      addChildNode(parentNodeId, insertedNode);
+      fileNotice.textContent = `Added ${insertedTagName} from clipboard HEX to ${parentTagName}.`;
+    }
+
+    function applyClipboardHexText(nodeId, mode, text) {
+      if (mode === 'add-child') {
+        addHexTextToNode(nodeId, text);
+        return;
+      }
+
+      insertHexTextBefore(nodeId, text);
+    }
+
+    async function applyClipboardHex(nodeId, mode) {
+      let text;
+      try {
+        text = await readClipboardText();
+      } catch (error) {
+        showClipboardInsertDialog(nodeId, mode, error.message);
+        return;
+      }
+
+      applyClipboardHexText(nodeId, mode, text);
+    }
     
     function hideNodeContextMenu() {
       activeContextNodeId = null;
       nodeContextMenu.classList.remove('open-left');
-      nodeContextMenu.querySelector('.context-menu-group')?.classList.remove('submenu-open');
-      nodeContextMenu.querySelector('.context-submenu-trigger')?.setAttribute('aria-expanded', 'false');
+      setContextSubmenuOpen(null);
       nodeContextMenu.hidden = true;
     }
     
-    function setSendToSubmenuOpen(open) {
-      const group = nodeContextMenu.querySelector('.context-menu-group');
-      const trigger = nodeContextMenu.querySelector('.context-submenu-trigger');
-      group?.classList.toggle('submenu-open', open);
-      trigger?.setAttribute('aria-expanded', String(open));
+    function setContextSubmenuOpen(openGroup) {
+      for (const group of nodeContextMenu.querySelectorAll('.context-menu-group')) {
+        const open = group === openGroup;
+        group.classList.toggle('submenu-open', open);
+        group.querySelector('.context-submenu-trigger')?.setAttribute('aria-expanded', String(open));
+      }
     }
     
     function setRadioValue(name, value) {
@@ -2365,6 +2501,27 @@ details[open] > summary .node-line {
       octetDialog.hidden = true;
       octetError.textContent = '';
       octetFileInput.value = '';
+    }
+
+    function showClipboardInsertDialog(nodeId, mode, errorMessage = '') {
+      activeClipboardInsertNodeId = nodeId;
+      activeClipboardInsertMode = mode;
+      clipboardInsertTitle.textContent = mode === 'add-child' ? 'Add from Clipboard HEX' : 'Insert from Clipboard HEX';
+      clipboardInsertSubmit.textContent = mode === 'add-child' ? 'Add' : 'Insert';
+      clipboardInsertHex.value = '';
+      clipboardInsertError.textContent = errorMessage ? `Clipboard read failed: ${errorMessage}` : '';
+      clipboardInsertDialog.hidden = false;
+      clipboardInsertHex.focus();
+      clipboardInsertHex.select();
+    }
+
+    function hideClipboardInsertDialog() {
+      activeClipboardInsertNodeId = null;
+      activeClipboardInsertMode = 'insert-before';
+      clipboardInsertDialog.hidden = true;
+      clipboardInsertError.textContent = '';
+      clipboardInsertSubmit.textContent = 'Insert';
+      clipboardInsertHex.value = '';
     }
 
     function showAboutDialog() {
@@ -2545,12 +2702,12 @@ details[open] > summary .node-line {
     
     function showNodeContextMenu(nodeId, x, y) {
       const node = nodeById.get(nodeId);
-      const addButton = nodeContextMenu.querySelector('[data-node-action="add-child"]');
+      const addGroup = nodeContextMenu.querySelector('[data-add-menu]');
       const extractedButton = nodeContextMenu.querySelector('[data-node-action="send-new-window-extracted"]');
-      addButton.hidden = !node?.constructed;
+      addGroup.hidden = !node?.constructed;
       extractedButton.hidden = !(node?.encapsulated && node.children.length > 0);
       activeContextNodeId = nodeId;
-      setSendToSubmenuOpen(false);
+      setContextSubmenuOpen(null);
       nodeContextMenu.classList.remove('open-left');
       nodeContextMenu.hidden = false;
     
@@ -2572,6 +2729,7 @@ details[open] > summary .node-line {
       hideEditDialog();
       hideTimeDialog();
       hideOctetDialog();
+      hideClipboardInsertDialog();
       viewer.classList.add('empty');
       viewer.innerHTML = 'No DER / PEM file selected yet.';
       fileNotice.textContent = 'PEM and headerless base64 input are decoded before parsing.';
@@ -2591,6 +2749,7 @@ details[open] > summary .node-line {
         hideEditDialog();
         hideTimeDialog();
         hideOctetDialog();
+        hideClipboardInsertDialog();
         viewer.classList.remove('empty');
         viewer.innerHTML = `<div class="error"><strong>Could not parse as DER.</strong><br>${escapeHtml(error.message)}</div>`;
       }
@@ -2627,6 +2786,7 @@ details[open] > summary .node-line {
       hideEditDialog();
       hideTimeDialog();
       hideOctetDialog();
+      hideClipboardInsertDialog();
       renderCurrentDocument();
       fileNotice.textContent = notice;
     }
@@ -2755,10 +2915,11 @@ details[open] > summary .node-line {
       const button = event.target.closest('button[data-node-action]');
       if (!button) return;
     
-      if (button.dataset.nodeAction === 'send-to') {
+      if (button.classList.contains('context-submenu-trigger')) {
         event.preventDefault();
-        const isOpen = button.closest('.context-menu-group')?.classList.contains('submenu-open');
-        setSendToSubmenuOpen(!isOpen);
+        const group = button.closest('.context-menu-group');
+        const isOpen = group?.classList.contains('submenu-open');
+        setContextSubmenuOpen(isOpen ? null : group);
         return;
       }
     
@@ -2769,9 +2930,9 @@ details[open] > summary .node-line {
     
       if (button.dataset.nodeAction === 'edit') {
         showDerDialog(node);
-      } else if (button.dataset.nodeAction === 'insert-before') {
+      } else if (button.dataset.nodeAction === 'insert-before-new-item') {
         showCreateDerDialog('insert-before', node);
-      } else if (button.dataset.nodeAction === 'add-child') {
+      } else if (button.dataset.nodeAction === 'add-child-new-item') {
         if (node.constructed) showCreateDerDialog('add-child', node);
       } else if (button.dataset.nodeAction === 'send-new-window') {
         openNodeSubtreeWindow(node);
@@ -2789,6 +2950,18 @@ details[open] > summary .node-line {
         } catch (error) {
           fileNotice.textContent = `Could not copy to the clipboard: ${error.message}`;
         }
+      } else if (button.dataset.nodeAction === 'insert-before-clipboard-hex') {
+        try {
+          await applyClipboardHex(nodeId, 'insert-before');
+        } catch (error) {
+          fileNotice.textContent = `Could not insert from the clipboard: ${error.message}`;
+        }
+      } else if (button.dataset.nodeAction === 'add-child-clipboard-hex') {
+        try {
+          await applyClipboardHex(nodeId, 'add-child');
+        } catch (error) {
+          fileNotice.textContent = `Could not add from the clipboard: ${error.message}`;
+        }
       } else if (button.dataset.nodeAction === 'delete') {
         deleteNode(nodeId);
       }
@@ -2797,17 +2970,13 @@ details[open] > summary .node-line {
     nodeContextMenu.addEventListener('pointerover', (event) => {
       const button = event.target.closest('button[data-node-action]');
       if (!button) return;
-      if (button.dataset.nodeAction === 'send-to' || button.closest('.node-context-submenu')) {
-        setSendToSubmenuOpen(true);
-      } else {
-        setSendToSubmenuOpen(false);
-      }
+      setContextSubmenuOpen(button.closest('.context-menu-group'));
     });
     
     nodeContextMenu.addEventListener('focusin', (event) => {
       const button = event.target.closest('button[data-node-action]');
       if (!button) return;
-      setSendToSubmenuOpen(button.dataset.nodeAction === 'send-to' || Boolean(button.closest('.node-context-submenu')));
+      setContextSubmenuOpen(button.closest('.context-menu-group'));
     });
     
     derForm.addEventListener('submit', (event) => {
@@ -2986,6 +3155,25 @@ details[open] > summary .node-line {
     octetDialog.addEventListener('click', (event) => {
       if (event.target === octetDialog) hideOctetDialog();
     });
+
+    clipboardInsertForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+
+      try {
+        applyClipboardHexText(activeClipboardInsertNodeId, activeClipboardInsertMode, clipboardInsertHex.value);
+        hideClipboardInsertDialog();
+      } catch (error) {
+        clipboardInsertError.textContent = error.message;
+      }
+    });
+
+    clipboardInsertForm.addEventListener('click', (event) => {
+      if (event.target.closest('button[data-clipboard-insert-action="cancel"]')) hideClipboardInsertDialog();
+    });
+
+    clipboardInsertDialog.addEventListener('click', (event) => {
+      if (event.target === clipboardInsertDialog) hideClipboardInsertDialog();
+    });
     
     editForm.addEventListener('submit', (event) => {
       event.preventDefault();
@@ -3027,6 +3215,7 @@ details[open] > summary .node-line {
         hideEditDialog();
         hideTimeDialog();
         hideOctetDialog();
+        hideClipboardInsertDialog();
         hideAboutDialog();
         hideTopMenus();
       }
@@ -3085,7 +3274,7 @@ details[open] > summary .node-line {
     if (defaultInstance || document.querySelector('script[data-pkistudio-auto-init="false"]')) return;
     const mount = document.querySelector('[data-pkistudio-mount], [data-pkistudio], #pkistudio');
     if (!mount) return;
-    defaultInstance = init({ mount });
+    defaultInstance = init({ mount, fullscreen: true });
   }
 
   if (document.readyState === 'loading') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,7 +136,9 @@ const APP_BASE_URL = import.meta.env.BASE_URL;
 const EMBEDDED_VIEWER_STYLES = `
 :host {
   min-height: 0 !important;
+  width: 100% !important;
   height: 100%;
+  overflow: hidden !important;
   background: transparent !important;
 }
 
@@ -160,9 +162,13 @@ main {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
+  gap: 6px;
   min-height: 0;
-  border-radius: 0 0 3px 3px !important;
+  border-right: 0 !important;
+  border-left: 0 !important;
+  border-radius: 0 !important;
   box-shadow: none !important;
+  overflow: hidden !important;
 }
 
 .picker {
@@ -182,7 +188,11 @@ main {
 :host(.pvkgadgets-viewer-readonly) [data-action="close"],
 :host(.pvkgadgets-viewer-readonly) [data-node-action="edit"],
 :host(.pvkgadgets-viewer-readonly) [data-node-action="insert-before"],
+:host(.pvkgadgets-viewer-readonly) [data-node-action="insert-before-new-item"],
+:host(.pvkgadgets-viewer-readonly) [data-node-action="insert-before-clipboard-hex"],
 :host(.pvkgadgets-viewer-readonly) [data-node-action="add-child"],
+:host(.pvkgadgets-viewer-readonly) [data-node-action="add-child-new-item"],
+:host(.pvkgadgets-viewer-readonly) [data-node-action="add-child-clipboard-hex"],
 :host(.pvkgadgets-viewer-readonly) [data-node-action="delete"],
 .pvkgadgets-viewer-readonly [data-action="toggle-load-menu"],
 .pvkgadgets-viewer-readonly [data-action="open"],
@@ -191,7 +201,11 @@ main {
 .pvkgadgets-viewer-readonly [data-action="close"],
 .pvkgadgets-viewer-readonly [data-node-action="edit"],
 .pvkgadgets-viewer-readonly [data-node-action="insert-before"],
+.pvkgadgets-viewer-readonly [data-node-action="insert-before-new-item"],
+.pvkgadgets-viewer-readonly [data-node-action="insert-before-clipboard-hex"],
 .pvkgadgets-viewer-readonly [data-node-action="add-child"],
+.pvkgadgets-viewer-readonly [data-node-action="add-child-new-item"],
+.pvkgadgets-viewer-readonly [data-node-action="add-child-clipboard-hex"],
 .pvkgadgets-viewer-readonly [data-node-action="delete"] {
   opacity: 0.45;
   pointer-events: none;
@@ -1363,7 +1377,7 @@ function listenForViewerChanges(instance: PkiStudioInstance): void {
   instance.root.addEventListener('submit', () => scheduleSelectedSubjectDnRefresh(instance), true);
   instance.root.addEventListener('click', (event) => {
     if (!(event.target instanceof Element)) return;
-    if (!event.target.closest('[data-node-action="delete"], [data-about-action], [data-edit-action="cancel"], [data-time-action="cancel"], [data-octet-action="cancel"], [data-der-action="cancel"]')) {
+    if (!event.target.closest('[data-node-action="delete"], [data-about-action], [data-edit-action="cancel"], [data-time-action="cancel"], [data-octet-action="cancel"], [data-der-action="cancel"], [data-clipboard-insert-action="cancel"]')) {
       scheduleSelectedSubjectDnRefresh(instance);
     }
   }, true);
@@ -1602,7 +1616,16 @@ function isReadonlyViewerAction(button: HTMLButtonElement): boolean {
   if (action === 'toggle-load-menu' || action === 'open' || action === 'load-clipboard-pem' || action === 'load-clipboard-hex' || action === 'close') return true;
 
   const nodeAction = button.dataset.nodeAction;
-  return nodeAction === 'edit' || nodeAction === 'delete' || nodeAction === 'add-child' || nodeAction === 'insert-before';
+  return (
+    nodeAction === 'edit' ||
+    nodeAction === 'delete' ||
+    nodeAction === 'add-child' ||
+    nodeAction === 'add-child-new-item' ||
+    nodeAction === 'add-child-clipboard-hex' ||
+    nodeAction === 'insert-before' ||
+    nodeAction === 'insert-before-new-item' ||
+    nodeAction === 'insert-before-clipboard-hex'
+  );
 }
 
 function renderKeyTree(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,6 +132,7 @@ const KEY_ALGORITHM_CANDIDATES: KeyAlgorithmCandidate[] = [
 ];
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
+const APP_VERSION = '0.0.5';
 
 const EMBEDDED_VIEWER_STYLES = `
 :host {
@@ -226,6 +227,7 @@ app.innerHTML = `
   <main class="shell">
     <nav class="toolbar" aria-label="Application">
       <strong>Private Key Gadgets</strong>
+      <button id="aboutButton" type="button">About</button>
     </nav>
     <section class="workspace">
       <section class="panel key-panel" aria-label="Generated key material">
@@ -360,9 +362,20 @@ app.innerHTML = `
         </div>
       </form>
     </dialog>
+    <dialog id="aboutDialog" class="about-dialog">
+      <section class="about-panel" role="document">
+        <p class="about-name">Private Key Gadgets</p>
+        <p class="about-version">Version ${APP_VERSION}</p>
+        <p class="about-detail">PkiStudioJS ${window.PkiStudio?.version ?? 'viewer'} embedded ASN.1 viewer</p>
+        <div class="dialog-actions">
+          <button id="closeAboutButton" type="button">Close</button>
+        </div>
+      </section>
+    </dialog>
   </main>
 `;
 
+const aboutButton = query<HTMLButtonElement>('#aboutButton');
 const newKeyButton = query<HTMLButtonElement>('#newKeyButton');
 const workspace = query<HTMLElement>('.workspace');
 const paneResizer = query<HTMLElement>('#paneResizer');
@@ -412,6 +425,8 @@ const selfSignedCertValidityDaysInput = query<HTMLInputElement>('#selfSignedCert
 const selfSignedCertKeyUsageList = query<HTMLElement>('#selfSignedCertKeyUsageList');
 const subjectDnDialog = query<HTMLDialogElement>('#subjectDnDialog');
 const subjectDnInput = query<HTMLInputElement>('#subjectDnInput');
+const aboutDialog = query<HTMLDialogElement>('#aboutDialog');
+const closeAboutButton = query<HTMLButtonElement>('#closeAboutButton');
 
 let viewer: PkiStudioInstance | null = null;
 let keyMaterials: KeyMaterial[] = [];
@@ -444,6 +459,15 @@ setBusy(true);
 clearApiLogButton.addEventListener('click', () => {
   apiLogList.replaceChildren();
   logApi('clear', 'API log cleared.');
+});
+
+aboutButton.addEventListener('click', () => {
+  aboutDialog.showModal();
+  closeAboutButton.focus();
+});
+
+closeAboutButton.addEventListener('click', () => {
+  aboutDialog.close();
 });
 
 window.addEventListener('DOMContentLoaded', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -265,8 +265,10 @@ app.innerHTML = `
           <button id="copyCsrPemMenuItem" type="button" role="menuitem" hidden>Copy as PEM</button>
           <button id="deleteChildItemMenuItem" type="button" role="menuitem">Delete</button>
         </div>
-        <div id="keyTree" class="tree empty">No key generated yet.</div>
-        <p id="formNotice" class="notice">Generated DER is sent to the ASN.1 viewer.</p>
+        <section class="key-card">
+          <div id="keyTree" class="tree empty">No key generated yet.</div>
+          <p id="formNotice" class="notice">Generated DER is sent to the ASN.1 viewer.</p>
+        </section>
       </section>
       <div id="paneResizer" class="pane-resizer" role="separator" aria-label="Resize panes" aria-orientation="vertical" tabindex="0"></div>
       <section class="viewer-panel" aria-label="ASN.1 viewer">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1662,12 +1662,15 @@ function renderKeyTree(): void {
 function renderSubjectDnNode(keyMaterial: KeyMaterial, subjectDn: SubjectDnMaterial): string {
   const selected = selectedNode?.keyId === keyMaterial.id && selectedNode.kind === 'subjectdn' && selectedNode.subjectDnId === subjectDn.id;
   return `
-    <div class="tree-row${selected ? ' selected' : ''}">
-      <button class="tree-icon-button" type="button" data-child-menu data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="subjectdn" data-subject-dn-id="${escapeHtml(subjectDn.id)}" aria-label="SubjectDN actions"><span class="tree-icon leaf" aria-hidden="true"></span></button>
-      <button class="tree-item" type="button" data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="subjectdn" data-subject-dn-id="${escapeHtml(subjectDn.id)}" aria-pressed="${selected}">
-        <span class="tree-tag">${escapeHtml(subjectDn.label)} (${subjectDn.bytes.byteLength})</span>
-      </button>
-    </div>
+    <details class="tree-node tree-leaf">
+      <summary class="tree-row${selected ? ' selected' : ''}">
+        <span class="tree-toggle" aria-hidden="true"></span>
+        <button class="tree-icon-button" type="button" data-child-menu data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="subjectdn" data-subject-dn-id="${escapeHtml(subjectDn.id)}" aria-label="SubjectDN actions"><span class="tree-icon leaf" aria-hidden="true"></span></button>
+        <button class="tree-item" type="button" data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="subjectdn" data-subject-dn-id="${escapeHtml(subjectDn.id)}" aria-pressed="${selected}">
+          <span class="tree-tag">${escapeHtml(subjectDn.label)} (${subjectDn.bytes.byteLength})</span>
+        </button>
+      </summary>
+    </details>
   `;
 }
 
@@ -1681,24 +1684,30 @@ function renderMaterialNode(keyMaterial: KeyMaterial, kind: KeyNodeKind, label: 
         ? `<button class="tree-icon-button" type="button" data-certificate-menu data-key-id="${escapeHtml(keyMaterial.id)}" aria-label="Certificate actions"><span class="tree-icon leaf" aria-hidden="true"></span></button>`
         : `<button class="tree-icon-button" type="button" data-child-menu data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="${kind}" aria-label="${label} actions"><span class="tree-icon leaf" aria-hidden="true"></span></button>`;
   return `
-    <div class="tree-row${selected ? ' selected' : ''}">
-      ${menuButton}
-      <button class="tree-item" type="button" data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="${kind}" aria-pressed="${selected}">
-      <span class="tree-tag">${label} (${bytes.byteLength})${escapeHtml(suffix)}</span>
-      </button>
-    </div>
+    <details class="tree-node tree-leaf">
+      <summary class="tree-row${selected ? ' selected' : ''}">
+        <span class="tree-toggle" aria-hidden="true"></span>
+        ${menuButton}
+        <button class="tree-item" type="button" data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="${kind}" aria-pressed="${selected}">
+          <span class="tree-tag">${label} (${bytes.byteLength})${escapeHtml(suffix)}</span>
+        </button>
+      </summary>
+    </details>
   `;
 }
 
 function renderCsrNode(keyMaterial: KeyMaterial, csr: CsrMaterial): string {
   const selected = selectedNode?.keyId === keyMaterial.id && selectedNode.kind === 'csr' && selectedNode.csrId === csr.id;
   return `
-    <div class="tree-row${selected ? ' selected' : ''}">
-      <button class="tree-icon-button" type="button" data-child-menu data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="csr" data-csr-id="${escapeHtml(csr.id)}" aria-label="CSR actions"><span class="tree-icon leaf" aria-hidden="true"></span></button>
-      <button class="tree-item" type="button" data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="csr" data-csr-id="${escapeHtml(csr.id)}" aria-pressed="${selected}">
-        <span class="tree-tag">${escapeHtml(csr.label)} (${csr.bytes.byteLength}) // ${escapeHtml(csr.hashAlgorithm)}</span>
-      </button>
-    </div>
+    <details class="tree-node tree-leaf">
+      <summary class="tree-row${selected ? ' selected' : ''}">
+        <span class="tree-toggle" aria-hidden="true"></span>
+        <button class="tree-icon-button" type="button" data-child-menu data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="csr" data-csr-id="${escapeHtml(csr.id)}" aria-label="CSR actions"><span class="tree-icon leaf" aria-hidden="true"></span></button>
+        <button class="tree-item" type="button" data-key-id="${escapeHtml(keyMaterial.id)}" data-key-node="csr" data-csr-id="${escapeHtml(csr.id)}" aria-pressed="${selected}">
+          <span class="tree-tag">${escapeHtml(csr.label)} (${csr.bytes.byteLength}) // ${escapeHtml(csr.hashAlgorithm)}</span>
+        </button>
+      </summary>
+    </details>
   `;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -183,8 +183,9 @@ select {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  border: 0;
   padding: 0;
-  background: var(--window);
+  background: transparent;
   overflow: hidden;
 }
 
@@ -215,10 +216,26 @@ button:disabled {
   flex-wrap: wrap;
   gap: 2px;
   align-items: center;
-  border-bottom: 1px solid var(--panel-border);
+  border: 1px solid var(--panel-border);
+  border-bottom: 0;
   border-radius: 0;
   padding: 4px;
   background: linear-gradient(#ffffff, var(--chrome));
+}
+
+.key-card {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  min-height: 0;
+  border: 1px solid var(--panel-border);
+  border-radius: 0;
+  padding: 6px;
+  background: var(--window);
+  box-shadow: none;
+  overflow: hidden;
 }
 
 .key-menu button {
@@ -345,7 +362,7 @@ button:disabled {
   align-content: start;
   gap: 0;
   flex: 1 1 auto;
-  min-height: 480px;
+  min-height: 0;
   overflow: auto;
   border: 1px solid var(--panel-border);
   border-radius: 3px;
@@ -574,11 +591,11 @@ button:disabled {
 
 .notice {
   flex: 0 0 auto;
-  min-height: 31px;
+  width: 100%;
+  min-height: 0;
   margin: 0;
-  border: 1px solid var(--panel-border);
-  border-top: 0;
-  padding: 7px 8px;
+  border: 0;
+  padding: 0;
   color: var(--muted);
   font-size: 12px;
   line-height: 1.35;

--- a/src/styles.css
+++ b/src/styles.css
@@ -348,8 +348,7 @@ button:disabled {
   min-height: 480px;
   overflow: auto;
   border: 1px solid var(--panel-border);
-  border-top: 0;
-  border-bottom: 0;
+  border-radius: 3px;
   padding: 4px 6px;
   background: #fff;
   font-family: Consolas, "Courier New", monospace;
@@ -389,6 +388,21 @@ button:disabled {
   display: none;
 }
 
+.tree-node summary::after,
+.tree-row::before {
+  content: "";
+  position: absolute;
+  top: 9px;
+  left: 8px;
+  width: 11px;
+  border-top: 1px dotted var(--tree-line);
+  transform: translateX(-100%);
+}
+
+.tree > .tree-node > summary::after {
+  display: none;
+}
+
 .tree-toggle {
   display: inline-grid;
   place-items: center;
@@ -408,6 +422,7 @@ button:disabled {
 }
 
 .tree-children {
+  position: relative;
   display: grid;
   gap: 0;
   margin-left: 19px;
@@ -415,7 +430,18 @@ button:disabled {
   border-left: 1px dotted var(--tree-line);
 }
 
+.tree-children::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: -1px;
+  width: 1px;
+  height: 8px;
+  background: #fff;
+}
+
 .tree-row {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 4px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,13 +23,26 @@
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
-  min-height: 100vh;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+body {
   color: var(--text);
   background: linear-gradient(#f7f9fc, var(--bg));
   font-family: Tahoma, "MS UI Gothic", "Yu Gothic UI", system-ui, sans-serif;
   font-size: 13px;
+}
+
+#app {
+  width: 100%;
+  height: 100dvh;
+  min-height: 0;
 }
 
 button,
@@ -39,9 +52,15 @@ select {
 }
 
 .shell {
-  width: min(1220px, calc(100% - 24px));
-  margin: 0 auto;
-  padding: 14px 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }
 
 .toolbar {
@@ -51,7 +70,7 @@ select {
   align-items: center;
   border: 1px solid var(--panel-border);
   border-bottom: 0;
-  border-radius: 6px 6px 0 0;
+  border-radius: 0;
   padding: 4px;
   background: linear-gradient(#ffffff, var(--chrome));
 }
@@ -62,13 +81,17 @@ select {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(280px, var(--key-panel-width, 360px)) 6px minmax(420px, 1fr);
+  flex: 1 1 auto;
+  grid-template-columns: minmax(280px, var(--key-panel-width, 360px)) 6px minmax(320px, 1fr);
   gap: 6px;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
   border: 1px solid var(--panel-border);
-  border-radius: 0 0 6px 6px;
+  border-radius: 0;
   padding: 8px;
   background: var(--window);
-  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: none;
 }
 
 .workspace.resizing {
@@ -102,7 +125,8 @@ select {
 }
 
 .api-log-panel {
-  margin-top: 8px;
+  flex: 0 0 auto;
+  margin-top: 0;
   padding: 0;
 }
 
@@ -139,8 +163,8 @@ select {
 .api-log-list {
   display: grid;
   align-content: start;
-  max-height: 160px;
-  min-height: 92px;
+  height: clamp(86px, 15dvh, 160px);
+  min-height: 0;
   overflow: auto;
   padding: 5px 6px;
   background: #fff;
@@ -737,18 +761,24 @@ button:disabled {
   display: flex;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
 }
 
 #viewerMount {
   flex: 1 1 auto;
   min-width: 0;
-  min-height: 560px;
-  height: min(720px, calc(100vh - 116px));
+  min-height: 0;
+  height: 100%;
 }
 
 @media (max-width: 820px) {
+  .shell {
+    overflow: auto;
+  }
+
   .workspace {
     grid-template-columns: 1fr;
+    overflow: visible;
   }
 
   .pane-resizer {
@@ -756,8 +786,8 @@ button:disabled {
   }
 
   #viewerMount {
-    height: auto;
-    min-height: 620px;
+    height: min(620px, 70dvh);
+    min-height: 420px;
   }
 
   .api-log-entry {

--- a/src/styles.css
+++ b/src/styles.css
@@ -79,6 +79,21 @@ select {
   padding: 4px 8px;
 }
 
+.toolbar button {
+  min-height: 0;
+  border-color: transparent;
+  padding: 4px 12px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.toolbar button:hover,
+.toolbar button:focus-visible {
+  border-color: #9dbce5;
+  background: #eaf3ff;
+  outline: none;
+}
+
 .workspace {
   display: grid;
   flex: 1 1 auto;
@@ -651,6 +666,42 @@ button:disabled {
 
 .password-dialog::backdrop {
   background: rgba(15, 23, 42, 0.2);
+}
+
+.about-dialog {
+  width: min(360px, calc(100% - 32px));
+  border: 0;
+  padding: 0;
+  color: var(--text);
+  background: transparent;
+}
+
+.about-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.2);
+}
+
+.about-panel {
+  display: grid;
+  gap: 8px;
+  border: 1px solid #8f98a3;
+  border-radius: 4px;
+  padding: 14px;
+  background: var(--panel);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.22);
+}
+
+.about-name {
+  margin: 0;
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.about-version,
+.about-detail {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .password-panel {

--- a/src/styles.css
+++ b/src/styles.css
@@ -389,9 +389,12 @@ button:disabled {
 }
 
 .tree-node summary::after,
-.tree-row::before {
+.tree-node .tree-node::before {
   content: "";
   position: absolute;
+}
+
+.tree-node summary::after {
   top: 9px;
   left: 8px;
   width: 11px;
@@ -399,8 +402,25 @@ button:disabled {
   transform: translateX(-100%);
 }
 
+.tree-node .tree-node {
+  margin-left: 19px;
+}
+
+.tree-node .tree-node::before {
+  top: -2px;
+  bottom: 8px;
+  left: -11px;
+  border-left: 1px dotted var(--tree-line);
+}
+
 .tree > .tree-node > summary::after {
   display: none;
+}
+
+.tree-leaf > summary .tree-toggle {
+  border-color: transparent;
+  background: transparent;
+  pointer-events: none;
 }
 
 .tree-toggle {
@@ -422,22 +442,9 @@ button:disabled {
 }
 
 .tree-children {
-  position: relative;
   display: grid;
   gap: 0;
-  margin-left: 19px;
   padding-left: 0;
-  border-left: 1px dotted var(--tree-line);
-}
-
-.tree-children::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: -1px;
-  width: 1px;
-  height: 8px;
-  background: #fff;
 }
 
 .tree-row {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,9 +5,17 @@
   --chrome: #f2f2f2;
   --panel: #ffffff;
   --panel-border: #b8c0ca;
+  --tree-line: #b9b9b9;
   --text: #111827;
   --muted: #5b6470;
   --accent: #2563eb;
+  --selection: #cfe8ff;
+  --selection-border: #99c7ee;
+  --folder: #f3c14f;
+  --folder-edge: #c69324;
+  --leaf: #f7f7f7;
+  --leaf-edge: #8b8b8b;
+  --comment: #4b5563;
   --danger: #b91c1c;
 }
 
@@ -176,6 +184,8 @@ select {
   min-width: 0;
   min-height: 0;
   padding: 0;
+  background: var(--window);
+  overflow: hidden;
 }
 
 button {
@@ -206,7 +216,7 @@ button:disabled {
   gap: 2px;
   align-items: center;
   border-bottom: 1px solid var(--panel-border);
-  border-radius: 3px 3px 0 0;
+  border-radius: 0;
   padding: 4px;
   background: linear-gradient(#ffffff, var(--chrome));
 }
@@ -331,10 +341,15 @@ button:disabled {
 }
 
 .tree {
+  display: grid;
+  align-content: start;
+  gap: 0;
   flex: 1 1 auto;
   min-height: 480px;
   overflow: auto;
-  border: 0;
+  border: 1px solid var(--panel-border);
+  border-top: 0;
+  border-bottom: 0;
   padding: 4px 6px;
   background: #fff;
   font-family: Consolas, "Courier New", monospace;
@@ -351,15 +366,23 @@ button:disabled {
 
 .tree-node {
   position: relative;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .tree-node summary {
+  position: relative;
   display: flex;
-  align-items: center;
+  flex-wrap: nowrap;
+  align-items: flex-start;
   gap: 4px;
-  min-height: 22px;
+  min-height: 19px;
+  padding: 1px 4px 1px 0;
   list-style: none;
   cursor: default;
+  white-space: nowrap;
+  line-height: 16px;
 }
 
 .tree-node summary::-webkit-details-marker {
@@ -369,42 +392,50 @@ button:disabled {
 .tree-toggle {
   display: inline-grid;
   place-items: center;
-  width: 14px;
-  height: 14px;
-  border: 1px solid #8f98a3;
+  position: relative;
+  z-index: 1;
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  margin-right: 2px;
+  border: 1px solid #7f7f7f;
   background: #fff;
-  color: #111827;
+  color: #333;
+  font: 10px/1 Arial, sans-serif;
   line-height: 1;
+  user-select: none;
 }
 
 .tree-children {
   display: grid;
   gap: 0;
   margin-left: 19px;
-  padding-left: 8px;
-  border-left: 1px dotted #b9b9b9;
+  padding-left: 0;
+  border-left: 1px dotted var(--tree-line);
 }
 
 .tree-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 4px;
   width: 100%;
-  min-height: 22px;
+  min-height: 19px;
   border: 1px solid transparent;
-  border-radius: 0;
-  padding: 1px 3px;
+  border-radius: 2px;
+  padding: 1px 3px 1px 0;
+  line-height: 16px;
 }
 
+.tree-node summary:hover,
 .tree-row:hover,
 .tree-row:focus-within {
-  border-color: var(--selection-border, #99c7ee);
-  background: var(--selection, #cfe8ff);
+  background: #eef6ff;
 }
 
 .tree-row.selected {
-  border-color: #99c7ee;
-  background: #cfe8ff;
+  border-color: var(--selection-border);
+  background: var(--selection);
 }
 
 .tree-item {
@@ -413,10 +444,11 @@ button:disabled {
   align-items: center;
   justify-content: flex-start;
   min-width: 0;
-  min-height: 18px;
+  min-height: 16px;
   border: 0;
   border-radius: 0;
   padding: 0;
+  color: var(--text);
   text-align: left;
   background: transparent;
   box-shadow: none;
@@ -433,8 +465,10 @@ button:disabled {
   flex: 0 0 auto;
   place-items: center;
   width: 15px;
-  height: 16px;
+  height: 12px;
   min-height: 0;
+  margin-top: 2px;
+  margin-right: 2px;
   border: 0;
   border-radius: 0;
   padding: 0;
@@ -445,53 +479,53 @@ button:disabled {
 
 .tree-icon-button:hover,
 .tree-icon-button:focus-visible {
-  outline: 1px solid var(--selection-border, #99c7ee);
-  background: #fff;
+  outline: none;
 }
 
 .tree-icon {
   position: relative;
   flex: 0 0 auto;
   width: 15px;
-  height: 14px;
+  height: 12px;
 }
 
 .tree-icon.folder::before {
   content: "";
   position: absolute;
   left: 1px;
-  top: 2px;
-  width: 8px;
+  top: 1px;
+  width: 7px;
   height: 4px;
-  border: 1px solid #c69324;
+  border: 1px solid var(--folder-edge);
   border-bottom: 0;
-  background: #ffe28f;
+  background: #ffe08a;
 }
 
 .tree-icon.folder::after {
   content: "";
   position: absolute;
   left: 0;
-  top: 5px;
+  top: 4px;
   width: 14px;
   height: 8px;
-  border: 1px solid #c69324;
-  background: linear-gradient(#ffe28f, #f3c14f);
+  border: 1px solid var(--folder-edge);
+  background: linear-gradient(#ffe28f, var(--folder));
 }
 
 .tree-icon.leaf::before {
   content: "";
   position: absolute;
   left: 2px;
-  top: 1px;
+  top: 0;
   width: 10px;
   height: 12px;
-  border: 1px solid #8b8b8b;
-  background: linear-gradient(135deg, transparent 0 18%, #dcdcdc 19% 26%, #f7f7f7 27%);
+  border: 1px solid var(--leaf-edge);
+  background: linear-gradient(135deg, transparent 0 18%, #dcdcdc 19% 26%, var(--leaf) 27%);
 }
 
 .tree-tag {
   color: var(--text);
+  font-weight: 400;
 }
 
 .key-label {
@@ -509,7 +543,8 @@ button:disabled {
   flex: 0 0 auto;
   min-height: 31px;
   margin: 0;
-  border-top: 1px solid var(--panel-border);
+  border: 1px solid var(--panel-border);
+  border-top: 0;
   padding: 7px 8px;
   color: var(--muted);
   font-size: 12px;


### PR DESCRIPTION
Updates the embedded PkiStudioJS viewer integration for upstream PkiStudioJS v0.2.4.

Summary:
- Vendor the PkiStudioJS v0.2.4 browser viewer asset.
- Adjust the embedded viewer overrides for the newer full-height viewer layout.
- Make pvkgadgets itself fill the browser viewport and let the workspace, key tree, ASN.1 viewer, and API log resize with the available browser area.
- Send PkiStudioJS New Window output from the embedded viewer to the standalone viewer.html page, so transferred data opens in a viewer-only PkiStudioJS window instead of the pvkgadgets app shell.
- Extend read-only viewer protection to the new Insert before/Add submenu actions, including New Item and Clipboard HEX actions.
- Align the left key pane, tree view area, icons, selection colors, and dotted tree connectors with the embedded PkiStudioJS viewer styling.
- Render left key tree child rows with the same details/summary structure used by PkiStudioJS so connector lines follow the same model.
- Wrap the left tree and message text in a PkiStudioJS-style card so the tree viewport and lower notice match the embedded viewer layout.
- Add a pvkgadgets About menu that displays the current app version and embedded PkiStudioJS viewer version.
- Bump pvkgadgets metadata to 0.0.5 and document the updated viewer behavior, layout, New Window flow, and About menu.

Verification:
- npm run check
- npm run build
- Browser verification at http://localhost:5173/: generated an EC P-256 key, confirmed PrivateKey selection disables Insert before/Add submenu actions, confirmed SubjectDN keeps editing actions enabled only for the editable selection, checked the left/right pane tree styling side by side after matching the tree DOM structure, verified the left tree card/notice computed layout matches the PkiStudioJS card/notice pattern, confirmed the app shell fills the viewport with document scroll size matching the viewport, verified embedded viewer New Window creates a viewer.html?subtree=... URL that opens PkiStudioJS Viewer without the pvkgadgets left pane, and confirmed the pvkgadgets About menu opens and displays Version 0.0.5 with PkiStudioJS 0.2.4.

Fixes #10
