### PR TITLE
Refine pane layout and resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.0.6
+Current version: 0.0.7
 
 ## Features
 
 ### Key Pair Management
 
 - Detects key pair algorithms supported by the current browser through WebCrypto.
-- Generates supported key pairs from the New Key menu, including RSA, EC, Ed25519, and X25519 when available.
+- Generates supported key pairs from the New menu, including RSA, EC, Ed25519, and X25519 when available.
 - Normalizes duplicate WebCrypto variants to the first supported key material for each family, such as RSA and EC.
 - Allows repeated New Key operations; each generated key pair is added as a separate top-level tree item.
 - Lets the top-level key pair label be edited in the tree.
@@ -19,7 +19,7 @@ Current version: 0.0.6
 
 ### PKCS#12 Import
 
-- Imports PKCS#12 files (`.p12`, `.pfx`) through the Open Key menu.
+- Imports PKCS#12 files (`.p12`, `.pfx`) through the Open menu.
 - Supports password-protected PKCS#12 files.
 - Extracts private key material and matching certificates when present.
 - Adds matching certificates as child items under the imported key pair.
@@ -48,7 +48,7 @@ Current version: 0.0.6
 
 ### PKCS#12 Export
 
-- Saves selected top-level key pair items through the Save Key menu.
+- Saves selected top-level key pair items through the Save menu.
 - Shows a checkbox list of key pair items before saving.
 - Checks the currently selected key pair by default when a tree item is already selected.
 - Prompts for a PKCS#12 password before writing the file.
@@ -58,7 +58,7 @@ Current version: 0.0.6
 
 ### Tree View
 
-- Displays key material in a PkiStudioJS-like tree with a menu area and message area.
+- Displays key material in a PkiStudioJS-like tree with compact New, Open, and Save actions plus a message area.
 - Uses a PkiStudioJS-style tree card, connector lines, node icons, selection colors, and lower message area for the left pane.
 - Supports multiple top-level key pair items.
 - Supports child items for SubjectDN, PrivateKey, PublicKey, Certificate, and CSR objects.
@@ -71,10 +71,12 @@ Current version: 0.0.6
 - Allows child items to be deleted from their icon menu.
 - Allows top-level key pair items to be deleted from their icon menu; deleting a key pair removes all child items as well.
 - Lets the left and right panes be resized with the splitter between them.
+- Centers the empty tree message in the left pane content area.
 
 ### Application Shell
 
 - Fills the browser viewport and resizes the workspace, key tree, ASN.1 viewer, and API Log with the available browser area.
+- Lets the bottom API Log pane be resized with the horizontal splitter between it and the upper workspace.
 - Follows the browser or operating system light/dark theme preference and passes the effective theme to embedded PkiStudioJS viewer windows.
 - Supports `?theme=light` and `?theme=dark` for forcing the application shell and embedded viewer to a specific theme.
 - Shows an About menu in the top application bar with the current Private Key Gadgets version.
@@ -126,7 +128,7 @@ Current version: 0.0.6
 - Logs operations such as PkiStudioJS initialization, WebCrypto key generation and export, PKCS#12 import/export, certificate loading, clipboard access, file-system saves, CSR creation, and self-signed certificate signing.
 - Displays timestamps with millisecond precision.
 - Keeps the newest 200 log entries and drops older entries automatically.
-- Provides a Clear button for resetting the visible log.
+- Provides a right-aligned Clear button for resetting the visible log.
 
 The application provides Save Key for exporting selected key pairs as PKCS#12 files. Individual DER objects are shown in the PkiStudioJS viewer, and users can use the viewer's Save menu when they want to write the currently displayed DER document to a file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,7 +134,7 @@ const KEY_ALGORITHM_CANDIDATES: KeyAlgorithmCandidate[] = [
 ];
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
-const APP_VERSION = '0.0.6';
+const APP_VERSION = '0.0.7';
 
 const EMBEDDED_VIEWER_STYLES = `
 :host {
@@ -235,11 +235,11 @@ app.innerHTML = `
       <section class="panel key-panel" aria-label="Generated key material">
         <nav class="key-menu" aria-label="Key actions">
           <div class="menu-group">
-            <button id="newKeyButton" type="button" aria-haspopup="menu" aria-expanded="false">New Key</button>
+            <button id="newKeyButton" type="button" aria-haspopup="menu" aria-expanded="false">New</button>
             <div id="algorithmMenu" class="submenu" role="menu" hidden></div>
           </div>
-          <button id="openKeyButton" type="button">Open Key</button>
-          <button id="saveKeyButton" type="button">Save Key</button>
+          <button id="openKeyButton" type="button">Open</button>
+          <button id="saveKeyButton" type="button">Save</button>
           <input id="openKeyInput" class="visually-hidden" type="file" accept=".p12,.pfx,application/pkcs12,application/x-pkcs12" />
           <input id="certificateInput" class="visually-hidden" type="file" accept=".cer,.crt,.der,.pem,application/pkix-cert,application/x-x509-ca-cert" />
         </nav>
@@ -279,9 +279,9 @@ app.innerHTML = `
         <div id="viewerMount" data-pkistudio-mount></div>
       </section>
     </section>
+    <div id="apiLogResizer" class="api-log-resizer" role="separator" aria-label="Resize API log" aria-orientation="horizontal" tabindex="0"></div>
     <section class="api-log-panel panel" aria-label="API log">
       <header class="api-log-header">
-        <strong>API Log</strong>
         <button id="clearApiLogButton" type="button">Clear</button>
       </header>
       <div id="apiLogList" class="api-log-list" role="log" aria-live="polite" aria-relevant="additions"></div>
@@ -381,6 +381,7 @@ const aboutButton = query<HTMLButtonElement>('#aboutButton');
 const newKeyButton = query<HTMLButtonElement>('#newKeyButton');
 const workspace = query<HTMLElement>('.workspace');
 const paneResizer = query<HTMLElement>('#paneResizer');
+const apiLogResizer = query<HTMLElement>('#apiLogResizer');
 const openKeyButton = query<HTMLButtonElement>('#openKeyButton');
 const saveKeyButton = query<HTMLButtonElement>('#saveKeyButton');
 const openKeyInput = query<HTMLInputElement>('#openKeyInput');
@@ -407,6 +408,7 @@ const keyTree = query<HTMLElement>('#keyTree');
 const formNotice = query<HTMLElement>('#formNotice');
 const viewerMount = query<HTMLElement>('#viewerMount');
 const apiLogList = query<HTMLElement>('#apiLogList');
+const apiLogPanel = query<HTMLElement>('.api-log-panel');
 const clearApiLogButton = query<HTMLButtonElement>('#clearApiLogButton');
 const pkcs12PasswordDialog = query<HTMLDialogElement>('#pkcs12PasswordDialog');
 const pkcs12PasswordTitle = query<HTMLElement>('#pkcs12PasswordTitle');
@@ -457,6 +459,7 @@ const CERTIFICATE_KEY_USAGES: CertificateKeyUsage[] = [
 
 applyRequestedTheme();
 setupPaneResizer();
+setupApiLogResizer();
 logApi('ready', 'Waiting for API activity.');
 setBusy(true);
 
@@ -1899,9 +1902,55 @@ function setupPaneResizer(): void {
   });
 }
 
+function setupApiLogResizer(): void {
+  const savedHeightText = localStorage.getItem('pvkgadgets.apiLogListHeight');
+  const savedHeight = savedHeightText === null ? NaN : Number(savedHeightText);
+  const initialHeight = Number.isFinite(savedHeight) ? savedHeight : apiLogList.getBoundingClientRect().height || 120;
+  setApiLogListHeight(initialHeight, false);
+
+  apiLogResizer.addEventListener('pointerdown', (event) => {
+    if (isSingleColumnLayout()) return;
+
+    event.preventDefault();
+    apiLogResizer.setPointerCapture(event.pointerId);
+    document.querySelector<HTMLElement>('.shell')?.classList.add('resizing-rows');
+    updateApiLogHeightFromPointer(event.clientY);
+  });
+
+  apiLogResizer.addEventListener('pointermove', (event) => {
+    if (!apiLogResizer.hasPointerCapture(event.pointerId)) return;
+    updateApiLogHeightFromPointer(event.clientY);
+  });
+
+  apiLogResizer.addEventListener('pointerup', finishApiLogResize);
+  apiLogResizer.addEventListener('pointercancel', finishApiLogResize);
+
+  apiLogResizer.addEventListener('keydown', (event) => {
+    if (isSingleColumnLayout()) return;
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Home' && event.key !== 'End') return;
+
+    event.preventDefault();
+    const currentHeight = Number(getComputedStyle(apiLogList).getPropertyValue('--api-log-list-height').replace('px', '')) || apiLogList.getBoundingClientRect().height || 120;
+    if (event.key === 'Home') setApiLogListHeight(getApiLogHeightBounds().min);
+    else if (event.key === 'End') setApiLogListHeight(getApiLogHeightBounds().max);
+    else setApiLogListHeight(currentHeight + (event.key === 'ArrowUp' ? 24 : -24));
+  });
+
+  window.addEventListener('resize', () => {
+    if (isSingleColumnLayout()) return;
+    const currentHeight = Number(getComputedStyle(apiLogList).getPropertyValue('--api-log-list-height').replace('px', '')) || apiLogList.getBoundingClientRect().height || 120;
+    setApiLogListHeight(currentHeight, false);
+  });
+}
+
 function finishPaneResize(event: PointerEvent): void {
   if (paneResizer.hasPointerCapture(event.pointerId)) paneResizer.releasePointerCapture(event.pointerId);
   workspace.classList.remove('resizing');
+}
+
+function finishApiLogResize(event: PointerEvent): void {
+  if (apiLogResizer.hasPointerCapture(event.pointerId)) apiLogResizer.releasePointerCapture(event.pointerId);
+  document.querySelector<HTMLElement>('.shell')?.classList.remove('resizing-rows');
 }
 
 function updateKeyPanelWidthFromPointer(clientX: number): void {
@@ -1919,6 +1968,21 @@ function setKeyPanelWidth(width: number, persist = true): void {
   if (persist) localStorage.setItem('pvkgadgets.keyPanelWidth', String(clampedWidth));
 }
 
+function updateApiLogHeightFromPointer(clientY: number): void {
+  const bounds = getApiLogHeightBounds();
+  setApiLogListHeight(bounds.bottom - clientY - bounds.resizerHeight - bounds.headerHeight - bounds.panelVerticalExtras);
+}
+
+function setApiLogListHeight(height: number, persist = true): void {
+  const bounds = getApiLogHeightBounds();
+  const clampedHeight = Math.round(Math.min(Math.max(height, bounds.min), bounds.max));
+  apiLogList.style.setProperty('--api-log-list-height', `${clampedHeight}px`);
+  apiLogResizer.setAttribute('aria-valuemin', String(bounds.min));
+  apiLogResizer.setAttribute('aria-valuemax', String(bounds.max));
+  apiLogResizer.setAttribute('aria-valuenow', String(clampedHeight));
+  if (persist) localStorage.setItem('pvkgadgets.apiLogListHeight', String(clampedHeight));
+}
+
 function getPaneWidthBounds(): { left: number; min: number; max: number } {
   const style = getComputedStyle(workspace);
   const rect = workspace.getBoundingClientRect();
@@ -1934,6 +1998,30 @@ function getPaneWidthBounds(): { left: number; min: number; max: number } {
     left: rect.left + borderLeft + paddingLeft,
     min,
     max: Math.max(min, contentWidth - splitterWidth - (columnGap * 2) - minViewerWidth)
+  };
+}
+
+function getApiLogHeightBounds(): { bottom: number; min: number; max: number; resizerHeight: number; headerHeight: number; panelVerticalExtras: number } {
+  const shell = query<HTMLElement>('.shell');
+  const shellRect = shell.getBoundingClientRect();
+  const workspaceRect = workspace.getBoundingClientRect();
+  const panelStyle = getComputedStyle(apiLogPanel);
+  const headerHeight = query<HTMLElement>('.api-log-header').getBoundingClientRect().height;
+  const resizerHeight = apiLogResizer.getBoundingClientRect().height || 6;
+  const panelVerticalExtras = (Number.parseFloat(panelStyle.borderTopWidth) || 0)
+    + (Number.parseFloat(panelStyle.borderBottomWidth) || 0)
+    + (Number.parseFloat(panelStyle.paddingTop) || 0)
+    + (Number.parseFloat(panelStyle.paddingBottom) || 0);
+  const min = 60;
+  const minWorkspaceHeight = 260;
+  const availableHeight = shellRect.height - (workspaceRect.top - shellRect.top) - resizerHeight - headerHeight - panelVerticalExtras;
+  return {
+    bottom: shellRect.bottom,
+    min,
+    max: Math.max(min, availableHeight - minWorkspaceHeight),
+    resizerHeight,
+    headerHeight,
+    panelVerticalExtras
   };
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -230,6 +230,11 @@ select {
   cursor: col-resize;
 }
 
+.shell.resizing-rows {
+  user-select: none;
+  cursor: row-resize;
+}
+
 .pane-resizer {
   position: relative;
   align-self: stretch;
@@ -248,6 +253,24 @@ select {
   outline: none;
 }
 
+.api-log-resizer {
+  position: relative;
+  flex: 0 0 6px;
+  min-height: 6px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: linear-gradient(0deg, transparent 0 2px, var(--splitter) 2px 3px, transparent 3px 6px);
+  cursor: row-resize;
+}
+
+.api-log-resizer:hover,
+.api-log-resizer:focus-visible,
+.shell.resizing-rows .api-log-resizer {
+  border-color: var(--hover-border);
+  background-color: var(--hover-bg);
+  outline: none;
+}
+
 .panel {
   border: 1px solid var(--panel-border);
   border-radius: 3px;
@@ -258,22 +281,19 @@ select {
 .api-log-panel {
   flex: 0 0 auto;
   margin-top: 0;
+  border: 0;
   padding: 0;
+  background: var(--window);
 }
 
 .api-log-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  border-bottom: 1px solid var(--panel-border);
-  border-radius: 3px 3px 0 0;
-  padding: 4px 6px 4px 8px;
-  background: linear-gradient(var(--chrome-start), var(--chrome));
-}
-
-.api-log-header strong {
-  font-weight: 700;
+  justify-content: flex-end;
+  border-bottom: 0;
+  border-radius: 0;
+  padding: 0 0 4px;
+  background: transparent;
 }
 
 .api-log-header button {
@@ -294,11 +314,11 @@ select {
 .api-log-list {
   display: grid;
   align-content: start;
-  height: clamp(86px, 15dvh, 160px);
+  height: var(--api-log-list-height, clamp(86px, 15dvh, 160px));
   min-height: 0;
   overflow: auto;
   padding: 5px 6px;
-  background: var(--panel);
+  background: transparent;
   font-family: Consolas, "Courier New", monospace;
   font-size: 12px;
   line-height: 1.35;
@@ -385,7 +405,9 @@ button:disabled {
   align-items: stretch;
   gap: 6px;
   min-height: 0;
-  border: 1px solid var(--panel-border);
+  border: 0;
+  border-top: 1px solid var(--panel-border);
+  border-bottom: 1px solid var(--panel-border);
   border-radius: 0;
   padding: 6px;
   background: var(--window);
@@ -519,10 +541,10 @@ button:disabled {
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: 3px;
   padding: 4px 6px;
-  background: var(--panel);
+  background: transparent;
   font-family: Consolas, "Courier New", monospace;
   font-size: 12px;
   line-height: 1.35;
@@ -530,6 +552,8 @@ button:disabled {
 
 .tree.empty {
   display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  align-content: stretch;
   place-items: center;
   color: var(--muted);
   font-family: Tahoma, "MS UI Gothic", "Yu Gothic UI", system-ui, sans-serif;
@@ -951,6 +975,10 @@ button:disabled {
   }
 
   .pane-resizer {
+    display: none;
+  }
+
+  .api-log-resizer {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- Flatten and align the left key tree, embedded viewer, and bottom API Log pane styling.
- Add a horizontal API Log splitter with persisted height and keyboard controls.
- Shorten left pane actions to New, Open, and Save, and bump the app to 0.0.7.

## Implementation notes
- The API Log title bar was removed while keeping the Clear button right-aligned.
- The bottom pane now shares the same `var(--window)` background as the upper panes in light and dark themes.
- The left tree empty state is centered and the left content card keeps top/bottom separator lines without side borders.

## Verification
- `npm run check`
- `npm run build`
- Browser verification in dark mode via `?theme=dark`: About shows 0.0.7, key generation works, pane backgrounds match, and API Log resizing persists.

Fixes #14