### PR TITLE
Reset viewer for key pair selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.0.7
+Current version: 0.0.8
 
 ## Features
 
@@ -70,6 +70,7 @@ Current version: 0.0.7
 - Provides Copy as PEM for CSR items from the child item icon menu.
 - Allows child items to be deleted from their icon menu.
 - Allows top-level key pair items to be deleted from their icon menu; deleting a key pair removes all child items as well.
+- Selecting a top-level key pair item resets the ASN.1 viewer to its initial empty display because the key pair itself does not contain DER data.
 - Lets the left and right panes be resized with the splitter between them.
 - Centers the empty tree message in the left pane content area.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,12 +46,6 @@ type SaveFileHandle = {
 };
 
 declare global {
-  interface ImportMeta {
-    readonly env: {
-      readonly BASE_URL: string;
-    };
-  }
-
   interface Window {
     PkiStudio?: PkiStudioApi;
     PkiStudioCore?: PkiStudioCoreApi;
@@ -81,7 +75,7 @@ type KeyMaterial = Omit<Pkcs12KeyMaterial, 'privateKeyDer' | 'publicKeyDer'> & {
   subjectDns?: SubjectDnMaterial[];
 };
 
-type KeyNodeKind = 'private' | 'public' | 'certificate' | 'csr' | 'subjectdn';
+type KeyNodeKind = 'keypair' | 'private' | 'public' | 'certificate' | 'csr' | 'subjectdn';
 
 type AppTheme = 'light' | 'dark';
 
@@ -134,7 +128,7 @@ const KEY_ALGORITHM_CANDIDATES: KeyAlgorithmCandidate[] = [
 ];
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
-const APP_VERSION = '0.0.7';
+const APP_VERSION = '0.0.8';
 
 const EMBEDDED_VIEWER_STYLES = `
 :host {
@@ -499,7 +493,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
 newKeyButton.addEventListener('click', () => {
   if (newKeyButton.disabled) return;
-  setAlgorithmMenuOpen(algorithmMenu.hidden);
+  setAlgorithmMenuOpen(isElementHidden(algorithmMenu));
 });
 
 algorithmMenu.addEventListener('click', async (event) => {
@@ -652,14 +646,31 @@ deleteChildItemMenuItem.addEventListener('click', () => {
 });
 
 keyTree.addEventListener('click', (event) => {
-  if (event.target instanceof Element && event.target.closest('[data-key-label]')) return;
+  const keyLabel = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-key-label]') : null;
+  if (keyLabel) {
+    event.preventDefault();
+    event.stopPropagation();
+    const keyId = keyLabel.dataset.keyId ?? '';
+    if (keyId) {
+      selectedNode = { keyId, kind: 'keypair' };
+      showSelectedNode();
+      markKeyPairSelected(keyId);
+    }
+    keyLabel.focus();
+    return;
+  }
 
   const keyPairMenuButton = event.target instanceof Element ? event.target.closest<HTMLButtonElement>('[data-keypair-menu]') : null;
   if (keyPairMenuButton) {
     event.preventDefault();
     event.stopPropagation();
     const keyId = keyPairMenuButton.dataset.keyId ?? '';
-    setKeyPairMenuOpen(keyPairMenuKeyId !== keyId || keyPairMenu.hidden, keyId, keyPairMenuButton);
+    if (keyId) {
+      selectedNode = { keyId, kind: 'keypair' };
+      showSelectedNode();
+      markKeyPairSelected(keyId);
+    }
+    setKeyPairMenuOpen(keyPairMenuKeyId !== keyId || isElementHidden(keyPairMenu), keyId, keyPairMenuButton);
     return;
   }
 
@@ -668,7 +679,7 @@ keyTree.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
     const keyId = certificateMenuButton.dataset.keyId ?? '';
-    setCertificateMenuOpen(certificateMenuKeyId !== keyId || certificateMenu.hidden, keyId, certificateMenuButton);
+    setCertificateMenuOpen(certificateMenuKeyId !== keyId || isElementHidden(certificateMenu), keyId, certificateMenuButton);
     return;
   }
 
@@ -677,7 +688,7 @@ keyTree.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
     setChildItemMenuOpen(
-      !isChildItemMenuTarget(childMenuButton) || childItemMenu.hidden,
+      !isChildItemMenuTarget(childMenuButton) || isElementHidden(childItemMenu),
       {
         keyId: childMenuButton.dataset.keyId ?? '',
         kind: childMenuButton.dataset.keyNode as KeyNodeKind,
@@ -694,7 +705,7 @@ keyTree.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
     const keyId = privateMenuButton.dataset.keyId ?? '';
-    setPrivateKeyMenuOpen(privateKeyMenuKeyId !== keyId || privateKeyMenu.hidden, keyId, privateMenuButton);
+    setPrivateKeyMenuOpen(privateKeyMenuKeyId !== keyId || isElementHidden(privateKeyMenu), keyId, privateMenuButton);
     return;
   }
 
@@ -1600,20 +1611,32 @@ function selectKeyNode(keyId: string, kind: KeyNodeKind, csrId?: string, subject
   showSelectedNode();
 }
 
+function markKeyPairSelected(keyId: string): void {
+  for (const summary of keyTree.querySelectorAll<HTMLElement>('.tree-node > summary.selected')) summary.classList.remove('selected');
+  for (const row of keyTree.querySelectorAll<HTMLElement>('.tree-row.selected')) row.classList.remove('selected');
+  for (const button of keyTree.querySelectorAll<HTMLButtonElement>('[data-key-node][aria-pressed="true"]')) button.setAttribute('aria-pressed', 'false');
+
+  const label = [...keyTree.querySelectorAll<HTMLElement>('[data-key-label]')].find((element) => element.dataset.keyId === keyId);
+  label?.closest<HTMLElement>('summary')?.classList.add('selected');
+}
+
 function showSelectedNode(): void {
   if (!selectedNode) {
+    viewer?.close?.();
     applyViewerEditState();
     return;
   }
 
   const keyMaterial = keyMaterials.find((material) => material.id === selectedNode?.keyId);
   if (!keyMaterial) {
+    viewer?.close?.();
     applyViewerEditState();
     return;
   }
 
   const bytes = getSelectedNodeBytes(keyMaterial, selectedNode);
   if (!bytes) {
+    viewer?.close?.();
     applyViewerEditState();
     return;
   }
@@ -1685,9 +1708,10 @@ function renderKeyTree(): void {
   keyTree.innerHTML = keyMaterials
     .map((keyMaterial) => {
       const info = recognizeKeyMaterial(keyMaterial);
+      const selected = selectedNode?.keyId === keyMaterial.id && selectedNode.kind === 'keypair';
       return `
     <details class="tree-node" open>
-      <summary>
+      <summary class="${selected ? 'selected' : ''}">
         <span class="tree-toggle" aria-hidden="true">−</span>
         <button class="tree-icon-button" type="button" data-keypair-menu data-key-id="${escapeHtml(keyMaterial.id)}" aria-label="KeyPair actions"><span class="tree-icon folder" aria-hidden="true"></span></button>
         <span class="tree-tag key-label" data-key-label data-key-id="${escapeHtml(keyMaterial.id)}" contenteditable="true" spellcheck="false">${escapeHtml(keyMaterial.label || info.label)}</span>
@@ -1768,6 +1792,8 @@ function renameKeyMaterial(keyId: string, label: string): void {
     return;
   }
 
+  if (keyMaterial.label === trimmedLabel) return;
+
   keyMaterial.label = trimmedLabel;
   renderKeyTree();
   setNotice(`Renamed key pair to ${trimmedLabel}.`);
@@ -1790,6 +1816,7 @@ function getSaveKeyNote(keyMaterial: KeyMaterial): string {
 }
 
 function getSelectedNodeBytes(keyMaterial: KeyMaterial, selected: SelectedKeyNode): Uint8Array | undefined {
+  if (selected.kind === 'keypair') return undefined;
   if (selected.kind === 'private') return keyMaterial.privateKeyDer;
   if (selected.kind === 'public') return keyMaterial.publicKeyDer;
   if (selected.kind === 'csr') return keyMaterial.csrs?.find((csr) => csr.id === selected.csrId)?.bytes;
@@ -2469,4 +2496,8 @@ function query<T extends Element>(selector: string): T {
   const element = document.querySelector<T>(selector);
   if (!element) throw new Error(`Missing element: ${selector}`);
   return element;
+}
+
+function isElementHidden(element: HTMLElement): boolean {
+  return element.hidden === true;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -662,6 +662,7 @@ button:disabled {
   background: var(--accent-soft);
 }
 
+.tree-node summary.selected,
 .tree-row.selected {
   border-color: var(--selection-border);
   background: var(--selection);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Selecting a top-level KeyPair item should not leave stale DER content in the embedded ASN.1 viewer, because the KeyPair itself has no DER bytes.

Summary:
- Treat top-level KeyPair entries as selectable nodes that reset the viewer to its initial empty state.
- Keep child DER selections, such as PrivateKey and PublicKey, loading in the viewer as before.
- Synchronize left-pane selection styling for KeyPair selections.
- Add Vite client typing and normalize `hidden` reads to clear editor diagnostics.
- Bump the app release version to 0.0.8 and document the behavior.

Verification:
- `npm run check`
- `npm run build`
- Browser: generated EC P-256, selected KeyPair and confirmed the viewer returned to `No DER / PEM file selected yet.`, then reselected PrivateKey and confirmed DER display returned.
- Browser: confirmed About shows `Version 0.0.8`.

Fixes #16