### PR TITLE
Release v0.1.1

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -72,7 +72,7 @@ Derive these from the invocation when possible:
    - If `version` is known and the change is release-worthy, update version references together.
    - If `version` is pending, leave existing released version references unchanged during implementation and note the deferred version bump in the issue and PR.
    - For pvkgadgets version bumps, update at least:
-     - `package.json` `version`
+     - `package.json` `version`, which is the source for the app and `window.PkiGadgetsCore.version`
      - `package-lock.json` root package version
      - `README.md` current version and any relevant feature documentation
    - Keep generated UI behavior consistent with the existing app style.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.1.0
+Current version: 0.1.1
 
 ## Features
 
@@ -172,7 +172,7 @@ Private Key Gadgets is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Vendor Assets
 
-The prototype vendors the PkiStudioJS 0.2.5 browser assets under `public/vendor/pkistudiojs/`:
+The prototype vendors the PkiStudioJS 0.2.6 browser assets under `public/vendor/pkistudiojs/`:
 
 - `pkistudio-core.js`
 - `pkistudio.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/public/vendor/pkistudiojs/pkistudio-core.js
+++ b/public/vendor/pkistudiojs/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.2.2';
+  const VERSION = '0.2.6';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/public/vendor/pkistudiojs/pkistudio.js
+++ b/public/vendor/pkistudiojs/pkistudio.js
@@ -1,6 +1,6 @@
 (() => {
   let defaultInstance = null;
-  const APP_VERSION = '0.2.5';
+  const APP_VERSION = '0.2.6';
 
   const APP_STYLES = `:host {
   color-scheme: light dark;

--- a/src/core.ts
+++ b/src/core.ts
@@ -108,7 +108,7 @@ export type PkiGadgetsCoreApi = {
 
 type Asn1Node = ReturnType<typeof asn1js.fromBER>['result'];
 
-const CORE_VERSION = '0.1.0';
+const CORE_VERSION = __PVKGADGETS_VERSION__;
 
 export const KEY_ALGORITHM_CANDIDATES: KeyAlgorithmCandidate[] = [
   ...createRsaCandidates('RSASSA-PKCS1-v1_5', 'SHA-256', ['sign', 'verify']),

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __PVKGADGETS_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
+const packageJson = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8')) as { version: string };
+
 export default defineConfig({
   base: './',
+  define: {
+    __PVKGADGETS_VERSION__: JSON.stringify(packageJson.version)
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary

- Update the vendored PkiStudioJS browser assets to v0.2.6.
- Bump pvkgadgets to v0.1.1 and source the public API/app version from package.json.
- Remove the npm private flag so future import-based consumers are not blocked by package metadata.
- Keep release workflow guidance aligned with package.json as the app/API version source.

## Verification

- `npm run check`
- `npm run build`
- Browser smoke test at `http://localhost:5174/`: `window.PkiGadgetsCore.version === "0.1.1"`, `window.PkiStudio.version === "0.2.6"`, and `generateKeyPair` is available.
- `npm pack --dry-run`

Fixes #20