### PR TITLE
Release v0.1.3 with PkiStudioJS 0.4.1

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -33,7 +33,7 @@ The release version may be omitted or set to `TBD` when development should proce
 - Create implementation work on a feature branch, never directly on `main`.
 - Do not merge the PR or publish the release until the user confirms they have reviewed the behavior, unless the user explicitly asks to proceed without that confirmation.
 - Use existing repository patterns and keep changes focused on the requested issue.
-- Keep `package.json` marked `private` unless the user explicitly asks to publish an npm package.
+- Preserve existing `package.json` package metadata unless the release requires a focused change. Do not add `private: true` only to prevent npm publication; npm publishing is outside this workflow unless explicitly requested.
 - Use non-interactive git commands.
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.1.2
+Current version: 0.1.3
 
 ## Features
 
@@ -175,8 +175,9 @@ Private Key Gadgets is licensed under the MIT License. See [LICENSE](LICENSE).
 The application imports PkiStudioJS from the published `pkistudiojs` npm package:
 
 - `pkistudiojs/core`
+- `pkistudiojs/oid-resolver`
 - `pkistudiojs/viewer`
 
-The PkiStudioJS OID name table is emitted as a Vite asset during development and production builds, so no vendored browser assets are required under `public/`.
+The PkiStudioJS OID name table is provided through `pkistudiojs/oid-resolver`, so no vendored browser assets are required under `public/`.
 
 PKCS#12 parsing is handled by PKIjs, with ASN.1 support from asn1js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pvkgadgets",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",
-        "pkistudiojs": "^0.3.0",
+        "pkistudiojs": "^0.4.1",
         "pvtsutils": "^1.3.6"
       },
       "devDependencies": {
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/pkistudiojs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pkistudiojs/-/pkistudiojs-0.3.0.tgz",
-      "integrity": "sha512-2Gcv/oTatuRS34BPhaCtmEsxdyc59j85tIYjHfEpx4WLIPH4Pv1Xzvdp4D3fyNDyxzCRprjx8HAQyNZGnbzxTQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkistudiojs/-/pkistudiojs-0.4.1.tgz",
+      "integrity": "sha512-pGleJVmcG86w/BxcmxBog5at/lvbStFT2UiOUhHpj37NtWLbX41PdSMCkZXtAePbqGkoLDzMDNz1tp0bfNz8iA==",
       "license": "MIT"
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.1.2",
-  "private": true,
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
@@ -17,7 +16,7 @@
   "dependencies": {
     "asn1js": "^3.0.10",
     "pkijs": "^3.4.0",
-    "pkistudiojs": "^0.3.0",
+    "pkistudiojs": "^0.4.1",
     "pvtsutils": "^1.3.6"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
   type RecognizedKeyInfo,
   type SubjectDnMaterial
 } from './core';
-import { PKISTUDIO_OIDS_URL, PkiStudio, PkiStudioCore } from './pkistudio';
+import { PkiStudio, PkiStudioCore, PkiStudioOidResolver } from './pkistudio';
 import type { PkiStudioApi, PkiStudioCoreApi, PkiStudioInstance } from './pkistudio-types';
 
 type SaveFilePickerOptions = {
@@ -395,11 +395,10 @@ window.addEventListener('DOMContentLoaded', async () => {
     return;
   }
 
-  installPkiStudioViewerWindowRouting();
-
   viewer = PkiStudio.init({
     mount: '#viewerMount',
-    oidUrl: PKISTUDIO_OIDS_URL
+    oidResolver: PkiStudioOidResolver,
+    newWindowUrl: 'viewer.html'
   });
   logApi('pkistudiojs.init', `Viewer ${PkiStudio.version ?? '(unknown version)'} mounted.`);
   applyEmbeddedViewerStyles(viewer);
@@ -1958,20 +1957,3 @@ function isElementHidden(element: HTMLElement): boolean {
   return element.hidden === true;
 }
 
-function installPkiStudioViewerWindowRouting(): void {
-  const originalOpen = window.open.bind(window);
-  window.open = (url?: string | URL, target?: string, features?: string) => {
-    return originalOpen(rewritePkiStudioViewerUrl(url), target, features);
-  };
-}
-
-function rewritePkiStudioViewerUrl(url?: string | URL): string | URL | undefined {
-  if (typeof url !== 'string') return url;
-
-  const parsedUrl = new URL(url, window.location.href);
-  if (!parsedUrl.searchParams.has('expand') && !parsedUrl.searchParams.has('subtree')) return url;
-
-  const viewerUrl = new URL('viewer.html', window.location.href);
-  viewerUrl.search = parsedUrl.search;
-  return viewerUrl.toString();
-}

--- a/src/pkistudio-types.ts
+++ b/src/pkistudio-types.ts
@@ -25,11 +25,20 @@ export type PkiStudioCoreApi = {
   parseElements: (bytes: Uint8Array, offset?: number, end?: number, depth?: number) => PkiStudioCoreNode[];
 };
 
+export type PkiStudioOidResolverApi = {
+  names: Record<string, string>;
+  resolve: (oid: string) => string;
+  create: (extraNames?: Record<string, string>) => PkiStudioOidResolverApi;
+};
+
 export type PkiStudioApi = {
   core?: PkiStudioCoreApi | null;
   init: (options: {
     mount: string | Element;
+    oidNames?: Record<string, string>;
+    oidResolver?: PkiStudioOidResolverApi | ((oid: string) => string);
     oidUrl?: string;
+    newWindowUrl?: string;
     shadowRoot?: boolean;
     fullscreen?: boolean;
   }) => PkiStudioInstance;

--- a/src/pkistudio.ts
+++ b/src/pkistudio.ts
@@ -1,11 +1,11 @@
 import importedCore from 'pkistudiojs/core';
+import importedOidResolver from 'pkistudiojs/oid-resolver';
 import importedViewer from 'pkistudiojs/viewer';
-import pkistudioOidsUrl from 'virtual:pkistudiojs-oids-url';
-import type { PkiStudioApi, PkiStudioCoreApi } from './pkistudio-types';
+import type { PkiStudioApi, PkiStudioCoreApi, PkiStudioOidResolverApi } from './pkistudio-types';
 
 export const PkiStudioCore = importedCore as PkiStudioCoreApi;
+export const PkiStudioOidResolver = importedOidResolver as PkiStudioOidResolverApi;
 export const PkiStudio = importedViewer as PkiStudioApi;
-export const PKISTUDIO_OIDS_URL = pkistudioOidsUrl;
 
 PkiStudio.core ??= PkiStudioCore;
 

--- a/src/pkistudiojs.d.ts
+++ b/src/pkistudiojs.d.ts
@@ -3,12 +3,12 @@ declare module 'pkistudiojs/core' {
   export default api;
 }
 
-declare module 'pkistudiojs/viewer' {
+declare module 'pkistudiojs/oid-resolver' {
   const api: unknown;
   export default api;
 }
 
-declare module 'virtual:pkistudiojs-oids-url' {
-  const url: string;
-  export default url;
+declare module 'pkistudiojs/viewer' {
+  const api: unknown;
+  export default api;
 }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,9 +1,9 @@
-import { PKISTUDIO_OIDS_URL, PkiStudio } from './pkistudio';
+import { PkiStudio, PkiStudioOidResolver } from './pkistudio';
 
 window.addEventListener('DOMContentLoaded', () => {
   PkiStudio.init({
     mount: '#pkistudio',
-    oidUrl: PKISTUDIO_OIDS_URL,
+    oidResolver: PkiStudioOidResolver,
     fullscreen: true
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,22 +3,9 @@ import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
 const packageJson = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8')) as { version: string };
-const pkistudioOidsPath = resolve(__dirname, 'node_modules/pkistudiojs/app/static/oids.json');
 
 export default defineConfig({
   base: './',
-  plugins: [
-    {
-      name: 'pkistudiojs-oids-url',
-      resolveId(id) {
-        return id === 'virtual:pkistudiojs-oids-url' ? '\0virtual:pkistudiojs-oids-url' : null;
-      },
-      load(id) {
-        if (id !== '\0virtual:pkistudiojs-oids-url') return null;
-        return `import url from ${JSON.stringify(`${pkistudioOidsPath}?url`)}; export default url;`;
-      }
-    }
-  ],
   define: {
     __PVKGADGETS_VERSION__: JSON.stringify(packageJson.version)
   },


### PR DESCRIPTION
## Summary
- update pvkgadgets to v0.1.3
- update `pkistudiojs` to `^0.4.1`
- use `pkistudiojs/oid-resolver` instead of Vite-emitted `oids.json`
- use PkiStudioJS `newWindowUrl` for right-pane New Window flows and remove the local `window.open` routing shim
- remove `private: true` from `package.json`
- update the release prompt so it no longer forces `private: true` for npm-publication avoidance

## Verification
- `npm run check`
- `npm run build`
- browser smoke test: main app loads and logs `Viewer 0.4.1 mounted`
- browser smoke test: standalone `viewer.html` loads
- browser smoke test: right-pane New Window action opens `viewer.html?subtree=...`

Fixes #24