### PR TITLE
Release v0.1.4 with viewer new-window fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.1.3
+Current version: 0.1.4
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pvkgadgets",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pvkgadgets",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pvkgadgets",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -2,7 +2,7 @@ import { PkiStudio, PkiStudioOidResolver } from './pkistudio';
 
 window.addEventListener('DOMContentLoaded', () => {
   PkiStudio.init({
-    mount: '#pkistudio',
+    mount: '#pkistudioViewer',
     oidResolver: PkiStudioOidResolver,
     fullscreen: true
   });

--- a/viewer.html
+++ b/viewer.html
@@ -7,7 +7,7 @@
     <title>PkiStudioJS Viewer</title>
   </head>
   <body>
-    <div id="pkistudio"></div>
-    <script type="module" src="/src/viewer.ts" data-pkistudio-auto-init="false"></script>
+    <div id="pkistudioViewer"></div>
+    <script type="module" src="/src/viewer.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update pvkgadgets to v0.1.4
- prevent PkiStudioJS auto-init from consuming standalone viewer transfer data before the pvkgadgets viewer entry initializes
- switch the standalone viewer mount from `#pkistudio` to `#pkistudioViewer`

## Verification
- `npm run check`
- `npm run build`
- production preview smoke test: right-pane New Window transfer opens `viewer.html?subtree=...` and displays the SEQUENCE content with OID names

Fixes #26