### PR TITLE
Rename core API and scope npm package

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -26,7 +26,7 @@ The release version may be omitted or set to `TBD` when development should proce
 
 - This prompt is a workflow guide only and does not grant repository permissions.
 - Push, tag, release, merge, and secret-backed Actions operations are possible only for users or tokens with the required repository permissions.
-- npm publication requires npm package ownership or a configured npm Trusted Publisher for `pkistudio/pvkgadgets` and `.github/workflows/publish-npm.yml`.
+- npm publication requires npm package ownership or a configured npm Trusted Publisher for `@pkistudio/pvkgadgets` and `.github/workflows/publish-npm.yml`.
 - Work in the current repository only.
 - Check the current branch, remote, and working tree before making changes.
 - Never discard uncommitted user changes.
@@ -54,7 +54,7 @@ Derive these from the invocation when possible:
    - Run a clean working tree check.
    - Confirm the current default branch and remote.
    - If `version` is known, check existing tags so the requested release version does not already exist.
-   - If `version` is known, check whether `pvkgadgets@<version>` is already published on npm so reruns do not attempt to publish an immutable version twice.
+   - If `version` is known, check whether `@pkistudio/pvkgadgets@<version>` is already published on npm so reruns do not attempt to publish an immutable version twice.
    - If `version` is pending, record that the final version must be chosen before version bumps, tagging, or release publication.
 
 2. Create Issue
@@ -74,7 +74,7 @@ Derive these from the invocation when possible:
    - If `version` is known and the change is release-worthy, update version references together.
    - If `version` is pending, leave existing released version references unchanged during implementation and note the deferred version bump in the issue and PR.
    - For pvkgadgets version bumps, update at least:
-     - `package.json` `version`, which is the source for the app and `window.PkiGadgetsCore.version`
+     - `package.json` `version`, which is the source for the app and `window.PvkGadgetsCore.version`
      - `package-lock.json` root package version
      - `README.md` current version and any relevant feature documentation
    - npm `exports`, package `files`, type declarations, and workflow metadata when the release changes npm package shape
@@ -125,7 +125,7 @@ Derive these from the invocation when possible:
     - Create an annotated tag `vX.Y.Z` on the merged `main` commit.
     - Push the tag.
          - The `Publish npm package` workflow runs on `v*` tag pushes and publishes with npm Trusted Publishing. It expects:
-            - npm package name: `pvkgadgets`
+            - npm package name: `@pkistudio/pvkgadgets`
             - GitHub owner/repository: `pkistudio/pvkgadgets`
             - workflow filename: `publish-npm.yml`
             - npm Trusted Publishing environment: none / blank, unless the workflow is later changed to use one.
@@ -133,7 +133,7 @@ Derive these from the invocation when possible:
          - If the version was already published manually, do not rerun the publish job for the same tag/version; npm versions are immutable and the rerun will fail.
     - Create a GitHub Release named `vX.Y.Z` with release notes summarizing user-facing changes and referencing the issue.
     - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
-      - After publication, verify `npm view pvkgadgets@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and import the package entry points.
+      - After publication, verify `npm view @pkistudio/pvkgadgets@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and import the package entry points.
 
 11. Deploy GitHub Pages
    - Confirm `.github/workflows/pages.yml` exists and deploys the Vite `dist` output to GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.2.0
+Current version: 0.3.0
 
 ## Features
 
@@ -123,9 +123,9 @@ Current version: 0.2.0
 - Opens PkiStudioJS New Window output in a standalone viewer-only page instead of a new pvkgadgets application shell.
 - Hides the standalone PkiStudioJS file picker in the embedded application shell.
 
-### PkiGadgetsCore API
+### PvkGadgetsCore API
 
-- Exposes `PkiGadgetsCore` through npm imports and `window.PkiGadgetsCore` as a UI-independent helper API for PKI operations used by the app.
+- Exposes `PvkGadgetsCore` through npm imports and `window.PvkGadgetsCore` as a UI-independent helper API for private-key operations used by the app.
 - Detects supported WebCrypto key pair algorithms and generates PKCS#8/SPKI DER key material.
 - Recognizes key families and labels from DER key material.
 - Creates SubjectDN DER, PKCS#10 CSR DER, and self-signed X.509 certificate DER without depending on the tree UI.
@@ -135,10 +135,10 @@ Current version: 0.2.0
 
 ### npm Package API
 
-- Exports the core helper API from `pvkgadgets` and `pvkgadgets/core`.
-- Exports PKCS#12 helpers from `pvkgadgets/pkcs12`.
-- Exports the browser app initializer from `pvkgadgets/app`.
-- Exports app styling from `pvkgadgets/styles.css`.
+- Exports the core helper API from `@pkistudio/pvkgadgets` and `@pkistudio/pvkgadgets/core`.
+- Exports PKCS#12 helpers from `@pkistudio/pvkgadgets/pkcs12`.
+- Exports the browser app initializer from `@pkistudio/pvkgadgets/app`.
+- Exports app styling from `@pkistudio/pvkgadgets/styles.css`.
 - Lets Webview hosts provide confirmation, save-file, and DER-viewer callbacks without depending on VS Code APIs inside this package.
 
 ### API Log
@@ -185,29 +185,29 @@ npm run pack:dry-run
 Install the package in a browser or Webview project:
 
 ```sh
-npm install pvkgadgets
+npm install @pkistudio/pvkgadgets
 ```
 
 Use the UI-independent API:
 
 ```ts
-import { PkiGadgetsCore } from 'pvkgadgets';
+import { PvkGadgetsCore } from '@pkistudio/pvkgadgets';
 
-const algorithms = await PkiGadgetsCore.getSupportedKeyAlgorithms();
-const keyPair = await PkiGadgetsCore.generateKeyPair(algorithms[0].id);
+const algorithms = await PvkGadgetsCore.getSupportedKeyAlgorithms();
+const keyPair = await PvkGadgetsCore.generateKeyPair(algorithms[0].id);
 ```
 
 Use the PKCS#12 helpers directly when a host application owns the surrounding UI:
 
 ```ts
-import { readPkcs12Keys, writePkcs12Keys } from 'pvkgadgets/pkcs12';
+import { readPkcs12Keys, writePkcs12Keys } from '@pkistudio/pvkgadgets/pkcs12';
 ```
 
 Mount the browser application from an embedded Webview or browser app:
 
 ```ts
-import { initPrivateKeyGadgets } from 'pvkgadgets/app';
-import 'pvkgadgets/styles.css';
+import { initPrivateKeyGadgets } from '@pkistudio/pvkgadgets/app';
+import '@pkistudio/pvkgadgets/styles.css';
 
 initPrivateKeyGadgets({
 	mount: '#app',
@@ -226,7 +226,7 @@ initPrivateKeyGadgets({
 });
 ```
 
-The package keeps VS Code-specific file access, dialogs, and Webview lifecycle outside `pvkgadgets`; hosts pass those behaviors through the `host` callbacks.
+The package keeps VS Code-specific file access, dialogs, and Webview lifecycle outside `@pkistudio/pvkgadgets`; hosts pass those behaviors through the `host` callbacks.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "pvkgadgets",
-  "version": "0.2.0",
+  "name": "@pkistudio/pvkgadgets",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pvkgadgets",
-      "version": "0.2.0",
+      "name": "@pkistudio/pvkgadgets",
+      "version": "0.3.0",
       "dependencies": {
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pvkgadgets",
-  "version": "0.2.0",
+  "name": "@pkistudio/pvkgadgets",
+  "version": "0.3.0",
   "description": "Browser PKI key material tools and reusable Private Key Gadgets API.",
   "type": "module",
   "main": "./dist/core.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,11 @@ import './styles.css';
 import { Certificate } from 'pkijs';
 import {
   CERTIFICATE_KEY_USAGES,
-  PkiGadgetsCore,
+  PvkGadgetsCore,
   type CsrMaterial,
   type KeyAlgorithmCandidate,
-  type PkiGadgetsCoreApi,
-  type PkiGadgetsKeyMaterial,
+  type PvkGadgetsCoreApi,
+  type PvkGadgetsKeyMaterial,
   type RecognizedKeyInfo,
   type SubjectDnMaterial
 } from './core';
@@ -27,12 +27,12 @@ declare global {
   interface Window {
     PkiStudio?: PkiStudioApi;
     PkiStudioCore?: PkiStudioCoreApi;
-    PkiGadgetsCore?: PkiGadgetsCoreApi;
+    PvkGadgetsCore?: PvkGadgetsCoreApi;
     showSaveFilePicker?: (options?: SaveFilePickerOptions) => Promise<SaveFileHandle>;
   }
 }
 
-type KeyMaterial = Omit<PkiGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'> & {
+type KeyMaterial = Omit<PvkGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'> & {
   privateKeyDer?: Uint8Array;
   publicKeyDer?: Uint8Array;
   csrs?: CsrMaterial[];
@@ -82,9 +82,9 @@ export type PrivateKeyGadgetsAppInstance = {
   close: () => void;
 };
 
-const APP_VERSION = PkiGadgetsCore.version;
+const APP_VERSION = PvkGadgetsCore.version;
 
-if (typeof window !== 'undefined') window.PkiGadgetsCore = PkiGadgetsCore;
+if (typeof window !== 'undefined') window.PvkGadgetsCore = PvkGadgetsCore;
 
 const EMBEDDED_VIEWER_STYLES = `
 :host {
@@ -722,7 +722,7 @@ async function generateKeyPair(selection: string): Promise<void> {
   try {
     logApi('WebCrypto.generateKey', `${selection} requested.`);
     logApi('WebCrypto.exportKey', 'Exporting generated key pair as PKCS#8/SPKI DER.');
-    const keyMaterial = await PkiGadgetsCore.generateKeyPair(selection, { createId: createKeyId });
+    const keyMaterial = await PvkGadgetsCore.generateKeyPair(selection, { createId: createKeyId });
 
     addKeyMaterial(keyMaterial);
     setNotice(`Generated ${recognizeKeyMaterial(keyMaterial).label}.`);
@@ -742,7 +742,7 @@ async function openPkcs12File(file: File, password: string): Promise<void> {
   try {
     const bytes = new Uint8Array(await file.arrayBuffer());
     logApi('PKCS#12.open', `Reading ${file.name} (${bytes.byteLength} bytes).`);
-    const openedKeys = (await PkiGadgetsCore.readPkcs12(bytes, password, { sourceName: file.name, createId: createKeyId })).map((key) => ({
+    const openedKeys = (await PvkGadgetsCore.readPkcs12(bytes, password, { sourceName: file.name, createId: createKeyId })).map((key) => ({
       ...key,
       label: key.label || getDefaultKeyLabel(key)
     }));
@@ -784,7 +784,7 @@ async function addCertificateBytes(keyId: string, certificateDer: Uint8Array, so
   setNotice(`Adding Certificate from ${sourceName}...`);
 
   try {
-    const certificate = Certificate.fromBER(PkiGadgetsCore.toArrayBuffer(certificateDer));
+    const certificate = Certificate.fromBER(PvkGadgetsCore.toArrayBuffer(certificateDer));
     const certificatePublicKeyDer = new Uint8Array(certificate.subjectPublicKeyInfo.toSchema().toBER(false));
     const match = await certificateMatchesKeyMaterial(keyMaterial, certificatePublicKeyDer);
 
@@ -812,7 +812,7 @@ async function savePkcs12File(keyIds: string[], password: string): Promise<void>
   try {
     const selectedKeys = keyIds.map((keyId) => keyMaterials.find((material) => material.id === keyId)).filter((material): material is KeyMaterial => Boolean(material));
     logApi('PKCS#12.save', `Creating PKCS#12 for ${selectedKeys.length} key pair${selectedKeys.length === 1 ? '' : 's'}.`);
-    const bytes = await PkiGadgetsCore.writePkcs12(selectedKeys, password);
+    const bytes = await PvkGadgetsCore.writePkcs12(selectedKeys, password);
     const fileName = getPkcs12FileName(selectedKeys);
     await saveBytesToFile(bytes, fileName);
     setNotice(`Saved ${selectedKeys.length} key pair${selectedKeys.length === 1 ? '' : 's'} to ${fileName}.`);
@@ -834,18 +834,18 @@ async function readCertificateFile(file: File): Promise<Uint8Array> {
 function readCertificatePemText(text: string): Uint8Array {
   const pemMatch = /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/i.exec(text);
   if (!pemMatch) throw new Error('Certificate PEM was not found.');
-  return PkiGadgetsCore.pemToDer(pemMatch[0], 'CERTIFICATE');
+  return PvkGadgetsCore.pemToDer(pemMatch[0], 'CERTIFICATE');
 }
 
 async function certificateMatchesKeyMaterial(keyMaterial: KeyMaterial, certificatePublicKeyDer: Uint8Array): Promise<boolean> {
-  if (keyMaterial.publicKeyDer) return PkiGadgetsCore.bytesEqual(keyMaterial.publicKeyDer, certificatePublicKeyDer);
+  if (keyMaterial.publicKeyDer) return PvkGadgetsCore.bytesEqual(keyMaterial.publicKeyDer, certificatePublicKeyDer);
   if (!keyMaterial.privateKeyDer) throw new Error('PrivateKey item is required before adding a certificate.');
 
   const info = recognizeKeyMaterial(keyMaterial);
   if (!info.canSign) throw new Error(`${info.label} cannot be checked against a certificate.`);
 
   logApi('WebCrypto.verify', `Checking certificate public key against ${info.label} private key.`);
-  const verified = await PkiGadgetsCore.verifyPrivateKeyMatchesPublicKey(keyMaterial.privateKeyDer, certificatePublicKeyDer, info);
+  const verified = await PvkGadgetsCore.verifyPrivateKeyMatchesPublicKey(keyMaterial.privateKeyDer, certificatePublicKeyDer, info);
   logApi('WebCrypto.verify', verified ? 'Certificate public key matched.' : 'Certificate public key did not match.', verified ? 'ok' : 'error');
   return verified;
 }
@@ -947,7 +947,7 @@ async function saveBytesToFile(bytes: Uint8Array, fileName: string): Promise<voi
     return;
   }
 
-  const blob = new Blob([PkiGadgetsCore.toArrayBuffer(bytes)], { type: 'application/x-pkcs12' });
+  const blob = new Blob([PvkGadgetsCore.toArrayBuffer(bytes)], { type: 'application/x-pkcs12' });
 
   if (window.showSaveFilePicker) {
     logApi('FileSystem.showSaveFilePicker', `Requesting save handle for ${fileName}.`);
@@ -1086,7 +1086,7 @@ async function createCsr(keyId: string, subjectDn: string, subjectBytes: Uint8Ar
 
     logApi('CSR.create', `Importing ${info.label} signing keys for ${hashAlgorithm}.`);
     logApi('CSR.sign', `Signing CSR for ${subjectDn}.`);
-    const result = await PkiGadgetsCore.createCsr({ privateKeyDer: keyMaterial.privateKeyDer, publicKeyDer: keyMaterial.publicKeyDer, subjectDn, subjectBytes, hashAlgorithm });
+    const result = await PvkGadgetsCore.createCsr({ privateKeyDer: keyMaterial.privateKeyDer, publicKeyDer: keyMaterial.publicKeyDer, subjectDn, subjectBytes, hashAlgorithm });
 
     const existing = keyMaterial.csrs?.[0];
     if (existing && !(await confirmAction('CSR item already exists. Overwrite it?'))) return;
@@ -1127,7 +1127,7 @@ async function createSelfSignedCertificate(keyId: string, subjectDn: string, sub
 
     logApi('Certificate.selfSign', `Importing ${info.label} signing keys for ${hashAlgorithm}; validity ${validityDays} days.`);
     logApi('Certificate.sign', `Signing self-signed certificate for ${subjectDn}.`);
-    const { bytes: certificateDer } = await PkiGadgetsCore.createSelfSignedCertificate({ privateKeyDer: keyMaterial.privateKeyDer, publicKeyDer: keyMaterial.publicKeyDer, subjectDn, subjectBytes, hashAlgorithm, validityDays, keyUsages });
+    const { bytes: certificateDer } = await PvkGadgetsCore.createSelfSignedCertificate({ privateKeyDer: keyMaterial.privateKeyDer, publicKeyDer: keyMaterial.publicKeyDer, subjectDn, subjectBytes, hashAlgorithm, validityDays, keyUsages });
     if (keyMaterial.certificateDer && !(await confirmAction('Certificate item already exists. Overwrite it?'))) return;
 
     keyMaterial.certificateDer = certificateDer;
@@ -1191,11 +1191,11 @@ async function upsertSubjectDn(keyMaterial: KeyMaterial, subjectDn: string, byte
 }
 
 function createSubjectDnBytes(subjectDn: string): Uint8Array {
-  return PkiGadgetsCore.createSubjectDn(subjectDn);
+  return PvkGadgetsCore.createSubjectDn(subjectDn);
 }
 
 function getCertificateSubjectDnBytes(certificateDer: Uint8Array): Uint8Array {
-  return PkiGadgetsCore.getCertificateSubjectDn(certificateDer);
+  return PvkGadgetsCore.getCertificateSubjectDn(certificateDer);
 }
 
 function getSubjectDnSource(keyId: string, action: string): { subjectDn: string; subjectBytes?: Uint8Array; error?: string } {
@@ -1206,7 +1206,7 @@ function getSubjectDnSource(keyId: string, action: string): { subjectDn: string;
   }
 
   try {
-    return { subjectDn: PkiGadgetsCore.subjectDnToString(subjectDn.bytes), subjectBytes: new Uint8Array(subjectDn.bytes) };
+    return { subjectDn: PvkGadgetsCore.subjectDnToString(subjectDn.bytes), subjectBytes: new Uint8Array(subjectDn.bytes) };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return { subjectDn: '(Invalid SubjectDN item)', error: `SubjectDN item could not be decoded: ${message}` };
@@ -1214,7 +1214,7 @@ function getSubjectDnSource(keyId: string, action: string): { subjectDn: string;
 }
 
 function subjectDnBytesToLdapString(bytes: Uint8Array): string {
-  return PkiGadgetsCore.subjectDnToString(bytes);
+  return PvkGadgetsCore.subjectDnToString(bytes);
 }
 
 function listenForViewerChanges(instance: PkiStudioInstance): void {
@@ -1287,7 +1287,7 @@ function updateSelectedSubjectDnBytes(bytes: Uint8Array): void {
 
   const keyMaterial = keyMaterials.find((material) => material.id === selectedNode?.keyId);
   const subjectDn = keyMaterial?.subjectDns?.find((item) => item.id === selectedNode?.subjectDnId);
-  if (!subjectDn || PkiGadgetsCore.bytesEqual(subjectDn.bytes, bytes)) return;
+  if (!subjectDn || PvkGadgetsCore.bytesEqual(subjectDn.bytes, bytes)) return;
 
   subjectDn.bytes = new Uint8Array(bytes);
   renderKeyTree();
@@ -1375,7 +1375,7 @@ async function readTextFromClipboard(): Promise<string> {
 }
 
 function derToPem(label: string, bytes: Uint8Array): string {
-  return PkiGadgetsCore.derToPem(label, bytes);
+  return PvkGadgetsCore.derToPem(label, bytes);
 }
 
 function getFirstSelectableNode(keyMaterial: KeyMaterial): SelectedKeyNode | null {
@@ -1981,7 +1981,7 @@ async function populateSupportedAlgorithms(): Promise<void> {
   supportedAlgorithms = [];
   algorithmMenu.textContent = '';
 
-  supportedAlgorithms = await PkiGadgetsCore.getSupportedKeyAlgorithms();
+  supportedAlgorithms = await PvkGadgetsCore.getSupportedKeyAlgorithms();
 
   if (supportedAlgorithms.length === 0) {
     algorithmMenu.innerHTML = '<button type="button" role="menuitem" disabled>No supported key pair algorithms</button>';
@@ -2006,7 +2006,7 @@ function setAlgorithmMenuOpen(open: boolean): void {
 }
 
 function recognizeKeyMaterial(material: Pick<KeyMaterial, 'privateKeyDer' | 'publicKeyDer'>): RecognizedKeyInfo {
-  return PkiGadgetsCore.recognizeKeyMaterial(material);
+  return PvkGadgetsCore.recognizeKeyMaterial(material);
 }
 
 function getPkiStudioCore(): PkiStudioCoreApi {

--- a/src/core.ts
+++ b/src/core.ts
@@ -17,7 +17,7 @@ export type SubjectDnMaterial = {
   bytes: Uint8Array;
 };
 
-export type PkiGadgetsKeyMaterial = Omit<Pkcs12KeyMaterial, 'privateKeyDer' | 'publicKeyDer'> & {
+export type PvkGadgetsKeyMaterial = Omit<Pkcs12KeyMaterial, 'privateKeyDer' | 'publicKeyDer'> & {
   privateKeyDer?: Uint8Array;
   publicKeyDer?: Uint8Array;
   csrs?: CsrMaterial[];
@@ -83,14 +83,14 @@ export type CertificateResult = {
   bytes: Uint8Array;
 };
 
-export type PkiGadgetsCoreApi = {
+export type PvkGadgetsCoreApi = {
   version: string;
   keyAlgorithms: KeyAlgorithmCandidate[];
   certificateKeyUsages: CertificateKeyUsage[];
   getSupportedKeyAlgorithms: () => Promise<KeyAlgorithmCandidate[]>;
-  generateKeyPair: (selection: string, options?: GenerateKeyPairOptions) => Promise<PkiGadgetsKeyMaterial>;
-  recognizeKeyMaterial: (material: Pick<PkiGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>) => RecognizedKeyInfo;
-  certificateMatchesKey: (material: Pick<PkiGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>, certificatePublicKeyDer: Uint8Array) => Promise<boolean>;
+  generateKeyPair: (selection: string, options?: GenerateKeyPairOptions) => Promise<PvkGadgetsKeyMaterial>;
+  recognizeKeyMaterial: (material: Pick<PvkGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>) => RecognizedKeyInfo;
+  certificateMatchesKey: (material: Pick<PvkGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>, certificatePublicKeyDer: Uint8Array) => Promise<boolean>;
   verifyPrivateKeyMatchesPublicKey: (privateKeyDer: Uint8Array, publicKeyDer: Uint8Array, info?: RecognizedKeyInfo) => Promise<boolean>;
   createSubjectDn: (subjectDn: string) => Uint8Array;
   getCertificateSubjectDn: (certificateDer: Uint8Array) => Uint8Array;
@@ -134,7 +134,7 @@ export const CERTIFICATE_KEY_USAGES: CertificateKeyUsage[] = [
   { id: 'decipherOnly', label: 'decipherOnly', bit: 8 }
 ];
 
-export const PkiGadgetsCore: PkiGadgetsCoreApi = {
+export const PvkGadgetsCore: PvkGadgetsCoreApi = {
   version: CORE_VERSION,
   keyAlgorithms: KEY_ALGORITHM_CANDIDATES,
   certificateKeyUsages: CERTIFICATE_KEY_USAGES,
@@ -174,7 +174,7 @@ async function getSupportedKeyAlgorithms(): Promise<KeyAlgorithmCandidate[]> {
   return [...uniqueSupportedAlgorithms.values()];
 }
 
-async function generateKeyPair(selection: string, options: GenerateKeyPairOptions = {}): Promise<PkiGadgetsKeyMaterial> {
+async function generateKeyPair(selection: string, options: GenerateKeyPairOptions = {}): Promise<PvkGadgetsKeyMaterial> {
   const { algorithm, usages } = getGenerationOptions(selection);
   const generated = await crypto.subtle.generateKey(algorithm, true, usages);
 
@@ -244,7 +244,7 @@ function isCryptoKeyPair(value: CryptoKey | CryptoKeyPair): value is CryptoKeyPa
   return 'privateKey' in value && 'publicKey' in value;
 }
 
-function recognizeKeyMaterial(material: Pick<PkiGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>): RecognizedKeyInfo {
+function recognizeKeyMaterial(material: Pick<PvkGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>): RecognizedKeyInfo {
   return (material.publicKeyDer ? recognizePublicKey(material.publicKeyDer) : null) ||
     (material.privateKeyDer ? recognizePrivateKey(material.privateKeyDer) : createRecognizedKeyInfo('Unknown', 'Unknown'));
 }
@@ -308,7 +308,7 @@ function createRecognizedKeyInfo(
   };
 }
 
-async function certificateMatchesKey(material: Pick<PkiGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>, certificatePublicKeyDer: Uint8Array): Promise<boolean> {
+async function certificateMatchesKey(material: Pick<PvkGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>, certificatePublicKeyDer: Uint8Array): Promise<boolean> {
   if (material.publicKeyDer) return bytesEqual(material.publicKeyDer, certificatePublicKeyDer);
   if (!material.privateKeyDer) throw new Error('PrivateKey item is required before adding a certificate.');
 
@@ -723,7 +723,7 @@ function curveNameFromOid(oid: string): string | undefined {
   return names[oid];
 }
 
-function getDefaultKeyLabel(keyMaterial: Pick<PkiGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>): string {
+function getDefaultKeyLabel(keyMaterial: Pick<PvkGadgetsKeyMaterial, 'privateKeyDer' | 'publicKeyDer'>): string {
   return recognizeKeyMaterial({ privateKeyDer: keyMaterial.privateKeyDer, publicKeyDer: keyMaterial.publicKeyDer }).label;
 }
 


### PR DESCRIPTION
## Summary
- Rename the reusable core API from `PkiGadgetsCore` to `PvkGadgetsCore`, including related exported types and the browser global.
- Change the npm package name to `@pkistudio/pvkgadgets` and bump the release metadata to `0.3.0`.
- Update README examples and the release workflow prompt for the new scoped npm package.

## Verification
- `npm run check`
- `npm run build`
- `npm run pack:dry-run`

Fixes #30