### PR TITLE
Use scoped PkiStudioJS viewer routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Current version: 0.3.0
 - Keeps Viewer editing actions enabled only while a SubjectDN item is selected.
 - Keeps the PkiStudioJS Save menu available for writing the currently displayed DER document to a file.
 - Opens PkiStudioJS New Window output in a standalone viewer-only page instead of a new pvkgadgets application shell.
-- Accepts PkiStudioJS New Window transfer data in the pvkgadgets app shell and routes it to either PKCS#12 import or the ASN.1 viewer by inspecting the transferred bytes.
+- Accepts PkiStudioJS New Window transfer data in the pvkgadgets app shell; PKCS#12 data is imported by pvkgadgets, while other ASN.1 data is redirected to the standalone viewer-only page.
 - Hides the standalone PkiStudioJS file picker in the embedded application shell.
 
 ### PvkGadgetsCore API

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Current version: 0.3.0
 ### PKCS#12 Import
 
 - Imports PKCS#12 files (`.p12`, `.pfx`) through the Open menu.
+- Routes Open menu input automatically: PKCS#12 data opens in pvkgadgets, while other ASN.1 DER or PEM data opens in the embedded PkiStudioJS viewer.
 - Supports password-protected PKCS#12 files.
 - Extracts private key material and matching certificates when present.
 - Adds matching certificates as child items under the imported key pair.
@@ -117,10 +118,11 @@ Current version: 0.3.0
 
 - Embeds the npm-provided PkiStudioJS viewer directly in the right pane.
 - Displays the selected PrivateKey, PublicKey, Certificate, SubjectDN, or CSR DER object.
+- Uses PkiStudioJS native read-only mode for read-only key material such as PrivateKey, PublicKey, Certificate, and CSR.
 - Keeps Viewer editing actions enabled only while a SubjectDN item is selected.
-- Disables the Viewer Load and Close actions, plus node Edit, Delete, Add, and Insert before actions, including the Insert before/Add submenus, for read-only key material such as PrivateKey, PublicKey, Certificate, and CSR.
 - Keeps the PkiStudioJS Save menu available for writing the currently displayed DER document to a file.
 - Opens PkiStudioJS New Window output in a standalone viewer-only page instead of a new pvkgadgets application shell.
+- Accepts PkiStudioJS New Window transfer data in the pvkgadgets app shell and routes it to either PKCS#12 import or the ASN.1 viewer by inspecting the transferred bytes.
 - Hides the standalone PkiStudioJS file picker in the embedded application shell.
 
 ### PvkGadgetsCore API
@@ -209,7 +211,7 @@ Mount the browser application from an embedded Webview or browser app:
 import { initPrivateKeyGadgets } from '@pkistudio/pvkgadgets/app';
 import '@pkistudio/pvkgadgets/styles.css';
 
-initPrivateKeyGadgets({
+const app = initPrivateKeyGadgets({
 	mount: '#app',
 	theme: 'dark',
 	host: {
@@ -224,6 +226,8 @@ initPrivateKeyGadgets({
 		}
 	}
 });
+
+await app.openBytes(new Uint8Array([0x30, 0x03, 0x02, 0x01, 0x01]), 'sample.der');
 ```
 
 The package keeps VS Code-specific file access, dialogs, and Webview lifecycle outside `@pkistudio/pvkgadgets`; hosts pass those behaviors through the `host` callbacks.
@@ -234,12 +238,12 @@ Private Key Gadgets is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## PkiStudioJS Dependency
 
-The application imports PkiStudioJS from the published `pkistudiojs` npm package:
+The application imports PkiStudioJS from the published `@pkistudio/pkistudiojs` npm package:
 
-- `pkistudiojs/core`
-- `pkistudiojs/oid-resolver`
-- `pkistudiojs/viewer`
+- `@pkistudio/pkistudiojs/core`
+- `@pkistudio/pkistudiojs/oid-resolver`
+- `@pkistudio/pkistudiojs/viewer`
 
-The PkiStudioJS OID name table is provided through `pkistudiojs/oid-resolver`, so no vendored browser assets are required under `public/`.
+The PkiStudioJS OID name table is provided through `@pkistudio/pkistudiojs/oid-resolver`, so no vendored browser assets are required under `public/`.
 
 PKCS#12 parsing is handled by PKIjs, with ASN.1 support from asn1js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
     "": {
       "name": "@pkistudio/pvkgadgets",
       "version": "0.3.0",
+      "license": "MIT",
       "dependencies": {
+        "@pkistudio/pkistudiojs": "^0.5.0",
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",
-        "pkistudiojs": "^0.4.1",
         "pvtsutils": "^1.3.6"
       },
       "devDependencies": {
@@ -472,6 +473,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@pkistudio/pkistudiojs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pkistudio/pkistudiojs/-/pkistudiojs-0.5.0.tgz",
+      "integrity": "sha512-DBU8KwMp6rW4WAAbnpYSUqZl2J1Bwj9fTV9tOMsdbqGFoqsM5ePANiQeAopVMgn6iB9XieD9JAzQ2PYFQLNY7g==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -993,12 +1000,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/pkistudiojs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkistudiojs/-/pkistudiojs-0.4.1.tgz",
-      "integrity": "sha512-pGleJVmcG86w/BxcmxBog5at/lvbStFT2UiOUhHpj37NtWLbX41PdSMCkZXtAePbqGkoLDzMDNz1tp0bfNz8iA==",
-      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.13",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "vite": "^7.0.0"
   },
   "dependencies": {
+    "@pkistudio/pkistudiojs": "^0.5.0",
     "asn1js": "^3.0.10",
     "pkijs": "^3.4.0",
-    "pkistudiojs": "^0.4.1",
     "pvtsutils": "^1.3.6"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -393,6 +393,7 @@ const bootViewer = async () => {
   }
 
   const transferredData = takeTransferredViewerData();
+  if (transferredData && !isPkcs12Data(transferredData.bytes, transferredData.label) && redirectToStandaloneViewer(transferredData)) return;
 
   viewer = PkiStudio.init({
     mount: viewerMount,
@@ -1486,17 +1487,22 @@ function isViewerEditableSelection(): boolean {
   return selectedNode?.kind === 'subjectdn';
 }
 
-function takeTransferredViewerData(): { label: string; bytes: Uint8Array } | null {
+function takeTransferredViewerData(): { label: string; bytes: Uint8Array; theme?: AppTheme } | null {
   const url = new URL(window.location.href);
   const transferType = url.searchParams.has('subtree') ? 'subtree' : 'expand';
   const key = url.searchParams.get(transferType);
   if (!key) return null;
+  const theme = url.searchParams.get('theme');
 
   try {
     const payload = JSON.parse(localStorage.getItem(key) || 'null') as { label?: string; bytes?: string } | null;
     localStorage.removeItem(key);
     if (!payload?.bytes) throw new Error('Transferred ASN.1 data was not found.');
-    return { label: payload.label || 'transferred ASN.1 data', bytes: getPkiStudioCore().base64ToBytes(payload.bytes) };
+    return {
+      label: payload.label || 'transferred ASN.1 data',
+      bytes: getPkiStudioCore().base64ToBytes(payload.bytes),
+      theme: theme === 'dark' || theme === 'light' ? theme : undefined
+    };
   } catch (error) {
     setNotice(error instanceof Error ? error.message : String(error), true);
     return null;
@@ -1505,6 +1511,26 @@ function takeTransferredViewerData(): { label: string; bytes: Uint8Array } | nul
     url.searchParams.delete('theme');
     window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
   }
+}
+
+function redirectToStandaloneViewer(transfer: { label: string; bytes: Uint8Array; theme?: AppTheme }): boolean {
+  const core = getPkiStudioCore();
+  const key = `pvkgadgets-viewer-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    localStorage.setItem(key, JSON.stringify({ label: transfer.label, bytes: core.bytesToBase64(transfer.bytes) }));
+  } catch (error) {
+    setNotice(error instanceof Error ? error.message : String(error), true);
+    return false;
+  }
+
+  const url = new URL(options.viewer?.newWindowUrl ?? 'viewer.html', window.location.href);
+  url.searchParams.set('subtree', key);
+  const theme = transfer.theme ?? getRequestedTheme();
+  if (theme) url.searchParams.set('theme', theme);
+  url.hash = '';
+  window.location.replace(url.toString());
+  return true;
 }
 
 function getViewerInputBytes(bytes: Uint8Array): Uint8Array {

--- a/src/app.ts
+++ b/src/app.ts
@@ -133,6 +133,11 @@ main {
   max-height: none !important;
 }
 
+:host([data-pvkgadgets-viewer-readonly="true"]) [data-node-action="edit"],
+[data-pvkgadgets-viewer-readonly="true"] [data-node-action="edit"] {
+  display: none !important;
+}
+
 @media (max-width: 820px) {
   .viewer {
     min-height: 520px !important;
@@ -1480,11 +1485,26 @@ function showSelectedNode(): void {
 }
 
 function applyViewerEditState(): void {
-  viewer?.setEditable?.(isViewerEditableSelection());
+  const editable = isViewerEditableSelection();
+  viewer?.setEditable?.(editable);
+  setEmbeddedViewerReadOnly(!editable);
 }
 
 function isViewerEditableSelection(): boolean {
   return selectedNode?.kind === 'subjectdn';
+}
+
+function setEmbeddedViewerReadOnly(readOnly: boolean): void {
+  const root = viewer?.root;
+  if (!root) return;
+  const value = String(readOnly);
+
+  if (root instanceof ShadowRoot) {
+    root.host.setAttribute('data-pvkgadgets-viewer-readonly', value);
+    return;
+  }
+
+  if (root instanceof Element) root.setAttribute('data-pvkgadgets-viewer-readonly', value);
 }
 
 function takeTransferredViewerData(): { label: string; bytes: Uint8Array; theme?: AppTheme } | null {

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import {
   type SubjectDnMaterial
 } from './core';
 import { PkiStudio, PkiStudioCore, PkiStudioOidResolver } from './pkistudio';
-import type { PkiStudioApi, PkiStudioCoreApi, PkiStudioInstance, PkiStudioOidResolverApi } from './pkistudio-types';
+import type { PkiStudioApi, PkiStudioCoreApi, PkiStudioCoreNode, PkiStudioInstance, PkiStudioOidResolverApi } from './pkistudio-types';
 
 type SaveFilePickerOptions = {
   suggestedName?: string;
@@ -52,8 +52,6 @@ type SelectedKeyNode = {
 
 type SupportedKeyAlgorithm = KeyAlgorithmCandidate;
 
-type ViewerRoot = DocumentFragment | Element;
-
 export type PrivateKeyGadgetsSaveFileRequest = {
   bytes: Uint8Array;
   suggestedName: string;
@@ -80,6 +78,7 @@ export type PrivateKeyGadgetsAppInstance = {
   readonly keys: readonly KeyMaterial[];
   readonly selectedNode: SelectedKeyNode | null;
   close: () => void;
+  openBytes: (bytes: Uint8Array, sourceName?: string) => Promise<void>;
 };
 
 const APP_VERSION = PvkGadgetsCore.version;
@@ -134,36 +133,6 @@ main {
   max-height: none !important;
 }
 
-:host(.pvkgadgets-viewer-readonly) [data-action="toggle-load-menu"],
-:host(.pvkgadgets-viewer-readonly) [data-action="open"],
-:host(.pvkgadgets-viewer-readonly) [data-action="load-clipboard-pem"],
-:host(.pvkgadgets-viewer-readonly) [data-action="load-clipboard-hex"],
-:host(.pvkgadgets-viewer-readonly) [data-action="close"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="edit"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="insert-before"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="insert-before-new-item"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="insert-before-clipboard-hex"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="add-child"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="add-child-new-item"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="add-child-clipboard-hex"],
-:host(.pvkgadgets-viewer-readonly) [data-node-action="delete"],
-.pvkgadgets-viewer-readonly [data-action="toggle-load-menu"],
-.pvkgadgets-viewer-readonly [data-action="open"],
-.pvkgadgets-viewer-readonly [data-action="load-clipboard-pem"],
-.pvkgadgets-viewer-readonly [data-action="load-clipboard-hex"],
-.pvkgadgets-viewer-readonly [data-action="close"],
-.pvkgadgets-viewer-readonly [data-node-action="edit"],
-.pvkgadgets-viewer-readonly [data-node-action="insert-before"],
-.pvkgadgets-viewer-readonly [data-node-action="insert-before-new-item"],
-.pvkgadgets-viewer-readonly [data-node-action="insert-before-clipboard-hex"],
-.pvkgadgets-viewer-readonly [data-node-action="add-child"],
-.pvkgadgets-viewer-readonly [data-node-action="add-child-new-item"],
-.pvkgadgets-viewer-readonly [data-node-action="add-child-clipboard-hex"],
-.pvkgadgets-viewer-readonly [data-node-action="delete"] {
-  opacity: 0.45;
-  pointer-events: none;
-}
-
 @media (max-width: 820px) {
   .viewer {
     min-height: 520px !important;
@@ -189,7 +158,7 @@ app.innerHTML = `
           </div>
           <button id="openKeyButton" type="button">Open</button>
           <button id="saveKeyButton" type="button">Save</button>
-          <input id="openKeyInput" class="visually-hidden" type="file" accept=".p12,.pfx,application/pkcs12,application/x-pkcs12" />
+          <input id="openKeyInput" class="visually-hidden" type="file" accept=".p12,.pfx,.der,.pem,.cer,.crt,.csr,.p7b,.p7c,.crl,.bin,application/pkcs12,application/x-pkcs12,application/pkix-cert,application/pkcs10,application/octet-stream,text/plain" />
           <input id="certificateInput" class="visually-hidden" type="file" accept=".cer,.crt,.der,.pem,application/pkix-cert,application/x-x509-ca-cert" />
         </nav>
         <div id="privateKeyMenu" class="node-context-menu" role="menu" hidden>
@@ -418,22 +387,26 @@ closeAboutButton.addEventListener('click', () => {
 
 const bootViewer = async () => {
   if (!PkiStudio) {
-    setNotice('pkistudiojs viewer could not be loaded.', true);
-    logApi('pkistudiojs.init', 'Viewer API was not available.', 'error');
+    setNotice('PkiStudioJS viewer could not be loaded.', true);
+    logApi('PkiStudioJS.init', 'Viewer API was not available.', 'error');
     return;
   }
+
+  const transferredData = takeTransferredViewerData();
 
   viewer = PkiStudio.init({
     mount: viewerMount,
     oidResolver: options.viewer?.oidResolver ?? PkiStudioOidResolver,
-    newWindowUrl: options.viewer?.newWindowUrl ?? 'viewer.html'
+    newWindowUrl: options.viewer?.newWindowUrl ?? 'viewer.html',
+    editable: false
   });
-  logApi('pkistudiojs.init', `Viewer ${PkiStudio.version ?? '(unknown version)'} mounted.`);
+  logApi('PkiStudioJS.init', `Viewer ${PkiStudio.version ?? '(unknown version)'} mounted.`);
   applyEmbeddedViewerStyles(viewer);
   applyViewerEditState();
   listenForViewerChanges(viewer);
 
   await populateSupportedAlgorithms();
+  if (transferredData) await openDataBytes(transferredData.bytes, transferredData.label);
 };
 
 if (document.readyState === 'loading') {
@@ -483,10 +456,7 @@ openKeyInput.addEventListener('change', async () => {
   openKeyInput.value = '';
   if (!file) return;
 
-  const password = await requestPkcs12Password(`Open ${file.name}`, { value: 'open', label: 'Open' });
-  if (password === null) return;
-
-  await openPkcs12File(file, password);
+  await openDataFile(file);
 });
 
 certificateInput.addEventListener('change', async () => {
@@ -735,14 +705,29 @@ async function generateKeyPair(selection: string): Promise<void> {
   }
 }
 
-async function openPkcs12File(file: File, password: string): Promise<void> {
+async function openDataFile(file: File): Promise<void> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  await openDataBytes(bytes, file.name);
+}
+
+async function openDataBytes(bytes: Uint8Array, sourceName = 'data'): Promise<void> {
+  if (isPkcs12Data(bytes, sourceName)) {
+    const password = await requestPkcs12Password(`Open ${sourceName}`, { value: 'open', label: 'Open' });
+    if (password === null) return;
+    await openPkcs12Bytes(bytes, sourceName, password);
+    return;
+  }
+
+  openAsn1ViewerBytes(bytes, sourceName);
+}
+
+async function openPkcs12Bytes(bytes: Uint8Array, sourceName: string, password: string): Promise<void> {
   setBusy(true);
-  setNotice(`Opening ${file.name}...`);
+  setNotice(`Opening ${sourceName}...`);
 
   try {
-    const bytes = new Uint8Array(await file.arrayBuffer());
-    logApi('PKCS#12.open', `Reading ${file.name} (${bytes.byteLength} bytes).`);
-    const openedKeys = (await PvkGadgetsCore.readPkcs12(bytes, password, { sourceName: file.name, createId: createKeyId })).map((key) => ({
+    logApi('PKCS#12.open', `Reading ${sourceName} (${bytes.byteLength} bytes).`);
+    const openedKeys = (await PvkGadgetsCore.readPkcs12(bytes, password, { sourceName, createId: createKeyId })).map((key) => ({
       ...key,
       label: key.label || getDefaultKeyLabel(key)
     }));
@@ -750,13 +735,28 @@ async function openPkcs12File(file: File, password: string): Promise<void> {
     for (const keyMaterial of openedKeys) addKeyMaterial(keyMaterial);
 
     const suffix = openedKeys.length === 1 ? '' : 's';
-    setNotice(`Opened ${openedKeys.length} key${suffix} from ${file.name}.`);
-    logApi('PKCS#12.open', `Opened ${openedKeys.length} key${suffix} from ${file.name}.`);
+    setNotice(`Opened ${openedKeys.length} key${suffix} from ${sourceName}.`);
+    logApi('PKCS#12.open', `Opened ${openedKeys.length} key${suffix} from ${sourceName}.`);
   } catch (error) {
     setNotice(error instanceof Error ? error.message : String(error), true);
     logApi('PKCS#12.open', error instanceof Error ? error.message : String(error), 'error');
   } finally {
     setBusy(false);
+  }
+}
+
+function openAsn1ViewerBytes(bytes: Uint8Array, sourceName: string): void {
+  try {
+    const viewerBytes = getViewerInputBytes(bytes);
+    const notice = `Opened ${sourceName} in the ASN.1 viewer.`;
+    selectedNode = null;
+    renderKeyTree();
+    showBytes(viewerBytes, notice);
+    setNotice(notice);
+    logApi('PkiStudioJS.viewer.open', `Opened ${sourceName} (${viewerBytes.byteLength} bytes).`);
+  } catch (error) {
+    setNotice(error instanceof Error ? error.message : String(error), true);
+    logApi('PkiStudioJS.viewer.open', error instanceof Error ? error.message : String(error), 'error');
   }
 }
 
@@ -1226,7 +1226,6 @@ function listenForViewerChanges(instance: PkiStudioInstance): void {
       void openViewerNodeInHost(event, instance);
     }, true);
   }
-  instance.root.addEventListener('click', guardReadonlyViewerAction, true);
   instance.root.addEventListener('submit', () => scheduleSelectedSubjectDnRefresh(instance), true);
   instance.root.addEventListener('click', (event) => {
     if (!(event.target instanceof Element)) return;
@@ -1398,7 +1397,7 @@ function getDeleteLabel(keyMaterial: KeyMaterial, target: SelectedKeyNode): stri
 
 function showBytes(bytes: Uint8Array, notice: string): void {
   if (!viewer) {
-    setNotice('pkistudiojs viewer is not ready yet.', true);
+    setNotice('PkiStudioJS viewer is not ready yet.', true);
     return;
   }
 
@@ -1479,54 +1478,63 @@ function showSelectedNode(): void {
   showBytes(bytes, `${info.label} ${label} (${format})`);
 }
 
-function guardReadonlyViewerAction(event: Event): void {
-  if (isViewerEditableSelection()) return;
-  const target = event.target instanceof Element ? event.target : null;
-  const button = target?.closest<HTMLButtonElement>('button[data-action], button[data-node-action]');
-  if (!button || !isReadonlyViewerAction(button)) return;
-
-  event.preventDefault();
-  event.stopImmediatePropagation();
-  setNotice('Viewer editing is available only while a SubjectDN item is selected.', true);
-}
-
 function applyViewerEditState(): void {
-  if (!viewer?.root) return;
-  const editable = isViewerEditableSelection();
-  const stateElement = getViewerStateElement(viewer.root);
-  stateElement?.classList.toggle('pvkgadgets-viewer-readonly', !editable);
-
-  for (const button of viewer.root.querySelectorAll<HTMLButtonElement>('button[data-action], button[data-node-action]')) {
-    if (!isReadonlyViewerAction(button)) continue;
-    button.disabled = !editable;
-    button.title = editable ? '' : 'Viewer editing is available only while a SubjectDN item is selected.';
-  }
+  viewer?.setEditable?.(isViewerEditableSelection());
 }
 
 function isViewerEditableSelection(): boolean {
   return selectedNode?.kind === 'subjectdn';
 }
 
-function getViewerStateElement(root: ViewerRoot): HTMLElement | null {
-  if (root instanceof ShadowRoot) return root.host instanceof HTMLElement ? root.host : null;
-  return root instanceof HTMLElement ? root : null;
+function takeTransferredViewerData(): { label: string; bytes: Uint8Array } | null {
+  const url = new URL(window.location.href);
+  const transferType = url.searchParams.has('subtree') ? 'subtree' : 'expand';
+  const key = url.searchParams.get(transferType);
+  if (!key) return null;
+
+  try {
+    const payload = JSON.parse(localStorage.getItem(key) || 'null') as { label?: string; bytes?: string } | null;
+    localStorage.removeItem(key);
+    if (!payload?.bytes) throw new Error('Transferred ASN.1 data was not found.');
+    return { label: payload.label || 'transferred ASN.1 data', bytes: getPkiStudioCore().base64ToBytes(payload.bytes) };
+  } catch (error) {
+    setNotice(error instanceof Error ? error.message : String(error), true);
+    return null;
+  } finally {
+    url.searchParams.delete(transferType);
+    url.searchParams.delete('theme');
+    window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+  }
 }
 
-function isReadonlyViewerAction(button: HTMLButtonElement): boolean {
-  const action = button.dataset.action;
-  if (action === 'toggle-load-menu' || action === 'open' || action === 'load-clipboard-pem' || action === 'load-clipboard-hex' || action === 'close') return true;
+function getViewerInputBytes(bytes: Uint8Array): Uint8Array {
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  if (/-----BEGIN [A-Z0-9 ]+-----/i.test(text)) return getPkiStudioCore().decodePem(text);
+  return bytes;
+}
 
-  const nodeAction = button.dataset.nodeAction;
-  return (
-    nodeAction === 'edit' ||
-    nodeAction === 'delete' ||
-    nodeAction === 'add-child' ||
-    nodeAction === 'add-child-new-item' ||
-    nodeAction === 'add-child-clipboard-hex' ||
-    nodeAction === 'insert-before' ||
-    nodeAction === 'insert-before-new-item' ||
-    nodeAction === 'insert-before-clipboard-hex'
-  );
+function isPkcs12Data(bytes: Uint8Array, sourceName = ''): boolean {
+  if (/\.(p12|pfx)$/i.test(sourceName)) return true;
+
+  try {
+    const core = getPkiStudioCore();
+    const [root] = core.parseElements(bytes, 0, bytes.byteLength);
+    const version = root?.children[0];
+    const authSafe = root?.children[1];
+    const contentType = authSafe?.children[0];
+    if (!root || root.tagClass !== 0 || root.tagNumber !== 16 || !root.constructed) return false;
+    if (!version || version.tagClass !== 0 || version.tagNumber !== 2 || !isIntegerValue(version, bytes, 3)) return false;
+    if (!authSafe || authSafe.tagClass !== 0 || authSafe.tagNumber !== 16 || !authSafe.constructed) return false;
+    if (!contentType || contentType.tagClass !== 0 || contentType.tagNumber !== 6) return false;
+    return core.decodeOid(bytes.slice(contentType.valueStart, contentType.valueEnd)) === '1.2.840.113549.1.7.1';
+  } catch {
+    return false;
+  }
+}
+
+function isIntegerValue(node: PkiStudioCoreNode, bytes: Uint8Array, expected: number): boolean {
+  const value = bytes.slice(node.valueStart, node.valueEnd);
+  return value.length > 0 && value.every((byte, index) => (index < value.length - 1 ? byte === 0 : byte === expected));
 }
 
 function renderKeyTree(): void {
@@ -2011,7 +2019,7 @@ function recognizeKeyMaterial(material: Pick<KeyMaterial, 'privateKeyDer' | 'pub
 
 function getPkiStudioCore(): PkiStudioCoreApi {
   const core = PkiStudio.core ?? PkiStudioCore;
-  if (!core) throw new Error('pkistudiojs CoreAPI could not be loaded.');
+  if (!core) throw new Error('PkiStudioJS CoreAPI could not be loaded.');
   return core;
 }
 
@@ -2055,6 +2063,9 @@ return {
   },
   close() {
     viewer?.close?.();
+  },
+  openBytes(bytes: Uint8Array, sourceName?: string) {
+    return openDataBytes(bytes, sourceName);
   }
 };
 }

--- a/src/pkistudio-types.ts
+++ b/src/pkistudio-types.ts
@@ -3,6 +3,7 @@ export type PkiStudioInstance = {
   getNodeBytes?: (nodeId: string) => Uint8Array;
   loadBytes: (bytes: Uint8Array, notice?: string) => void;
   root?: DocumentFragment | Element;
+  setEditable?: (editable: boolean) => void;
 };
 
 export type PkiStudioCoreNode = {
@@ -44,6 +45,7 @@ export type PkiStudioApi = {
     newWindowUrl?: string;
     shadowRoot?: boolean;
     fullscreen?: boolean;
+    editable?: boolean;
   }) => PkiStudioInstance;
   version?: string;
 };

--- a/src/pkistudio.ts
+++ b/src/pkistudio.ts
@@ -1,6 +1,6 @@
-import importedCore from 'pkistudiojs/core';
-import importedOidResolver from 'pkistudiojs/oid-resolver';
-import importedViewer from 'pkistudiojs/viewer';
+import importedCore from '@pkistudio/pkistudiojs/core';
+import importedOidResolver from '@pkistudio/pkistudiojs/oid-resolver';
+import importedViewer from '@pkistudio/pkistudiojs/viewer';
 import type { PkiStudioApi, PkiStudioCoreApi, PkiStudioOidResolverApi } from './pkistudio-types';
 
 export const PkiStudioCore = importedCore as PkiStudioCoreApi;

--- a/src/pkistudiojs.d.ts
+++ b/src/pkistudiojs.d.ts
@@ -1,14 +1,14 @@
-declare module 'pkistudiojs/core' {
+declare module '@pkistudio/pkistudiojs/core' {
   const api: unknown;
   export default api;
 }
 
-declare module 'pkistudiojs/oid-resolver' {
+declare module '@pkistudio/pkistudiojs/oid-resolver' {
   const api: unknown;
   export default api;
 }
 
-declare module 'pkistudiojs/viewer' {
+declare module '@pkistudio/pkistudiojs/viewer' {
   const api: unknown;
   export default api;
 }


### PR DESCRIPTION
Summary:
- Switch PkiStudioJS imports and dependency to `@pkistudio/pkistudiojs@^0.5.0`.
- Initialize the embedded PkiStudioJS viewer with native read-only mode and use `setEditable()` only for SubjectDN edits.
- Route opened or transferred data by content: PKCS#12 opens in pvkgadgets, while non-PKCS#12 startup transfers redirect to the standalone `viewer.html` PkiStudioJS viewer.
- Expose data routing through `initPrivateKeyGadgets().openBytes()` and document the behavior.

Release notes draft:
pvkgadgets now uses the scoped PkiStudioJS package, delegates read-only viewer behavior to PkiStudioJS, imports PKCS#12 startup transfers into pvkgadgets, and redirects non-PKCS#12 ASN.1 startup transfers to the standalone PkiStudioJS viewer.

Verification:
- `npm run check`
- `npm run build`
- `npm run pack:dry-run`
- Browser: confirmed PkiStudioJS 0.5.0 mounts in pvkgadgets.
- Browser: confirmed PkiStudioJS-style `subtree` transfer with DER redirects from pvkgadgets to `viewer.html` and opens in the normal viewer.
- Browser: confirmed PkiStudioJS-style `subtree` transfer with a PKCS#12 payload prompts for a password and imports the key material into pvkgadgets.

Fixes #32