### PR TITLE
Update PkiStudioJS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private Key Gadgets is an experimental browser tool for generating and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree on the left, and sends the selected DER object to the embedded PkiStudioJS ASN.1 viewer on the right.
 
-Current version: 0.3.1
+Current version: 0.4.0
 
 ## Features
 
@@ -119,7 +119,7 @@ Current version: 0.3.1
 - Embeds the npm-provided PkiStudioJS viewer directly in the right pane.
 - Displays the selected PrivateKey, PublicKey, Certificate, SubjectDN, or CSR DER object.
 - Uses PkiStudioJS native read-only mode for read-only key material such as PrivateKey, PublicKey, Certificate, and CSR.
-- Keeps Viewer editing actions enabled only while a SubjectDN item is selected.
+- Keeps Viewer editing actions enabled only while a SubjectDN item is selected, including PkiStudioJS tag-edit support.
 - Keeps the PkiStudioJS Save menu available for writing the currently displayed DER document to a file.
 - Opens PkiStudioJS New Window output in a standalone viewer-only page instead of a new pvkgadgets application shell.
 - Accepts PkiStudioJS New Window transfer data in the pvkgadgets app shell; PKCS#12 data is imported by pvkgadgets, while other ASN.1 data is redirected to the standalone viewer-only page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@pkistudio/pvkgadgets",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pvkgadgets",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@pkistudio/pkistudiojs": "^0.5.0",
+        "@pkistudio/pkistudiojs": "^0.6.0",
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",
         "pvtsutils": "^1.3.6"
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@pkistudio/pkistudiojs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@pkistudio/pkistudiojs/-/pkistudiojs-0.5.0.tgz",
-      "integrity": "sha512-DBU8KwMp6rW4WAAbnpYSUqZl2J1Bwj9fTV9tOMsdbqGFoqsM5ePANiQeAopVMgn6iB9XieD9JAzQ2PYFQLNY7g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pkistudio/pkistudiojs/-/pkistudiojs-0.6.0.tgz",
+      "integrity": "sha512-+tbYo8vrjo7mK+lGbnCOoDJUYEnGEnsD/6oNVDvrufChyF5ONZU8lnomp7YVVrIX9aubHV/5bI419yaH6T60FQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pvkgadgets",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Browser PKI key material tools and reusable Private Key Gadgets API.",
   "type": "module",
   "main": "./dist/core.js",
@@ -58,7 +58,7 @@
     "vite": "^7.0.0"
   },
   "dependencies": {
-    "@pkistudio/pkistudiojs": "^0.5.0",
+    "@pkistudio/pkistudiojs": "^0.6.0",
     "asn1js": "^3.0.10",
     "pkijs": "^3.4.0",
     "pvtsutils": "^1.3.6"


### PR DESCRIPTION
Summary:
- Update `@pkistudio/pkistudiojs` from `^0.5.0` to `^0.6.0` so the embedded viewer includes tag-edit support in Edit flows.
- Bump `@pkistudio/pvkgadgets` metadata to `0.4.0`.
- Update README version and embedded viewer notes.

Release notes draft:
Update the embedded PkiStudioJS viewer to include Edit support for changing ASN.1 tags.

Verification:
- `npm run check`
- `npm run build`
- `npm run pack:dry-run`

Closes #34