### PR TITLE
Add wiki and ADR maintenance setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,19 @@
   "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git-lfs:1": {}
-  }
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+  },
+  "forwardPorts": [5173, 4567],
+  "portsAttributes": {
+    "5173": {
+      "label": "pvkgadgets",
+      "onAutoForward": "openPreview"
+    },
+    "4567": {
+      "label": "pvkgadgets wiki",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/setup-wiki.sh"
 }

--- a/.devcontainer/setup-wiki.sh
+++ b/.devcontainer/setup-wiki.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WIKI_REMOTE="${WIKI_REMOTE:-https://github.com/pkistudio/pvkgadgets.wiki.git}"
+WIKI_DIR="${WIKI_DIR:-/workspaces/pvkgadgets.wiki}"
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+if ! command_exists ruby || ! command_exists gem; then
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ruby-full \
+    build-essential \
+    zlib1g-dev \
+    cmake \
+    pkg-config \
+    libssl-dev
+fi
+
+if ! command_exists gollum; then
+  sudo gem install gollum --no-document
+fi
+
+if [ ! -d "$WIKI_DIR" ]; then
+  if ! git clone "$WIKI_REMOTE" "$WIKI_DIR"; then
+    cat <<EOF
+Wiki repository could not be cloned from:
+  $WIKI_REMOTE
+
+If the GitHub Wiki has not been initialized yet, create the first Home page in
+GitHub's Wiki tab, then rerun this script.
+EOF
+  fi
+elif [ ! -d "$WIKI_DIR/.git" ]; then
+  echo "Wiki directory exists but is not a Git repository: $WIKI_DIR"
+else
+  echo "Wiki repository already exists: $WIKI_DIR"
+fi
+
+echo "Gollum is ready. Run: gollum --host 0.0.0.0 --port 4567 $WIKI_DIR"

--- a/.github/instructions/adr.instructions.md
+++ b/.github/instructions/adr.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "docs/adr/**/*.md"
+---
+
+When writing an ADR, record only one architectural decision per file.
+
+Focus on why the decision was made, not on implementation steps.
+
+Each ADR must include the following sections:
+
+- Status
+- Context
+- Decision
+- Alternatives
+- Consequences
+
+If an existing ADR is replaced by a new decision, do not delete the old ADR. Mark the old ADR as `Superseded` and keep a reference to the new ADR.
+
+Use clear and concise language. Avoid long explanations unless they are necessary to understand the decision.
+
+When possible, include links to related issues, pull requests, design notes, or other ADRs.

--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when: running the pvkgadgets issue-to-release workflow, including issue creation, branch work, PR, merge, tag, GitHub Release, npm publish, Trusted Publishing, GitHub Pages status, and Actions checks."
+description: "Use when: running the pvkgadgets issue-to-release workflow, including issue creation, ADR assessment, wiki maintenance, branch work, PR, merge, tag, GitHub Release, npm publish, Trusted Publishing, GitHub Pages status, and Actions checks."
 name: "pvkgadgets release workflow"
 argument-hint: "[version|TBD] [#issue] <short feature or fix summary>"
 agent: "agent"
@@ -31,12 +31,15 @@ Default assumptions:
 - If no issue number is supplied, create a tracking issue first.
 - If an issue number is supplied, use that issue as the source of truth.
 - Create a branch from the issue, implement the requested change, verify it, push it, and open a PR.
+- Assess whether issue-level architectural decisions should be captured in ADRs under `docs/adr/`; ask the user only when you judge that a new ADR may be warranted and the user has not already requested or declined one.
+- Assess whether user-facing behavior, package API behavior, release process expectations, or operating procedures should be reflected in the GitHub Wiki, and keep wiki work separate from the main repository PR.
 - Use the issue body, issue comments, and PR body to preserve the release rationale, release notes draft, verification results, and publication status.
 - Do not merge, tag, publish, or create a GitHub Release until the user explicitly says to proceed.
 
 Ask only when:
 
 - The requested version is missing and the workflow has reached a version-required step.
+- The issue appears to introduce a meaningful ADR-worthy architectural decision and the user has not already requested or declined ADR creation.
 - The working tree has unrelated uncommitted changes.
 - npm or GitHub permissions block progress.
 - The issue requirements are ambiguous enough that implementation could go in the wrong direction.
@@ -59,6 +62,11 @@ Confirmation gates:
 - If unrelated local changes exist, stop and ask how to proceed.
 - Create implementation work on a feature branch, never directly on `main`.
 - Use existing repository patterns and keep changes focused on the requested issue.
+- Do not create ADRs for trivial implementation details, routine bug fixes, or decisions already covered by an existing ADR.
+- When adding or updating ADRs, use `docs/adr/0000-template.md` and keep the ADR focused on why the decision was made, alternatives considered, and expected consequences.
+- Do not add a new ADR solely on agent judgment without user confirmation, unless the user explicitly requested ADR creation in the invocation or issue discussion.
+- Keep GitHub Wiki work in the wiki repository, normally `/workspaces/pvkgadgets.wiki`, and do not mix wiki commits into the main repository PR.
+- Do not push wiki changes until the user has asked for publication or confirmed the prepared wiki content.
 - Preserve existing `package.json` package metadata unless the release requires a focused change. Do not add `private: true` only to prevent npm publication.
 - Use non-interactive git commands.
 
@@ -70,6 +78,8 @@ Derive these from the invocation when possible:
 - `issueNumber`: existing GitHub issue number when the invocation includes a `#<number>` reference or an unambiguous issue URL.
 - `summary`: short feature or fix summary.
 - `issueBody`: issue requirements. If the user supplied detailed requirements, preserve them.
+- `architectureDecision`: issue-level design decision, if the issue includes one that should be recorded in `docs/adr/`.
+- `wikiWork`: user-facing documentation or operating procedure updates that should be reflected in the GitHub Wiki.
 - `verificationPlan`: expected local checks. If not supplied, infer from the changed area.
 
 ## Standard Record Templates
@@ -89,6 +99,12 @@ Use this shape for PR bodies:
 ```md
 Summary:
 - ...
+
+ADR:
+- Added/updated/referenced: ...
+
+Wiki:
+- Added/updated/pushed: ...
 
 Release notes draft:
 ...
@@ -118,13 +134,38 @@ Closes #<issue-number>
    - Record the issue number for the branch, PR body, and final report.
    - Prefer GitHub tools when available. If the GitHub CLI is unavailable and `GITHUB_TOKEN` is set, use the GitHub REST API with `curl`. Never print token values.
 
-3. Create Branch
+3. Assess ADR Needs
+   - Review `docs/adr/` before implementation when the issue involves external dependencies, package export strategy, public API design, cryptographic algorithms or key management, PKCS#12 handling, certificate or CSR semantics, host integration boundaries, deployment architecture, runtime infrastructure, or major framework or library choices.
+   - Ask the user about ADR creation only when you judge that the issue introduces a meaningful architectural decision that is not already covered by an existing ADR.
+   - Do not ask about ADRs for routine fixes, implementation details, local refactors, documentation-only changes, release bookkeeping, or decisions already covered by an existing ADR.
+   - If the user already requested ADR creation, proceed with the ADR without asking again.
+   - If the user already declined ADR creation for the issue, continue without asking again.
+   - When asking, briefly explain the suspected decision, why it may deserve an ADR, and the proposed ADR title. Keep the question concise and offer a clear yes/no path.
+   - If the user confirms, add a new ADR under `docs/adr/` using `docs/adr/0000-template.md`.
+   - If the user declines, continue without an ADR and mention the decision in the PR body when useful.
+   - Number new ADRs sequentially and use a concise kebab-case filename such as `0001-keep-host-neutral-browser-api.md`.
+   - In the ADR, reference the source issue and any related ADRs in the `Related` section.
+   - If the implementation follows an existing ADR, mention that ADR in the PR body instead of creating a duplicate ADR.
+   - If the issue appears to conflict with an existing ADR, stop and ask how to proceed before implementing the conflicting change.
+
+4. Assess Wiki Needs
+   - Use the GitHub Wiki for user-facing operational guidance, reusable API guidance, release process notes, screenshots, and documentation that should be browsed outside the package README.
+   - Keep README updates in the main repository when they describe package installation, package exports, current version, or npm-facing documentation. Use the wiki for expanded workflows and maintenance guidance.
+   - If wiki changes are needed, work in `/workspaces/pvkgadgets.wiki` when it exists. If it is missing, run `.devcontainer/setup-wiki.sh` or clone `https://github.com/pkistudio/pvkgadgets.wiki.git` next to the main workspace.
+   - Follow the existing wiki structure and PkiStudioJS-style conventions: Markdown pages at the wiki root, `_Sidebar.md` for navigation, `images/` for screenshots, and root `favicon.ico` for the wiki favicon.
+   - Validate wiki links and image references before committing. For Gollum preview, use the VS Code task `Start pvkgadgets wiki` or run `gollum --host 0.0.0.0 --port 4567 /workspaces/pvkgadgets.wiki`; if port `4567` is already in use, use a temporary alternate port and stop it when done.
+   - Commit wiki changes in the wiki repository separately from the main repository implementation branch.
+   - Push wiki changes only after the user has asked for publication or confirmed the prepared wiki content. Record pushed wiki commit hashes in the issue or final report when relevant.
+
+5. Create Branch
    - Create a branch named `issue-<number>-<short-kebab-summary>`.
    - Switch to it before editing files.
 
-4. Implement
+6. Implement
    - Read the relevant files before editing.
    - Update app code and documentation for the requested behavior.
+   - Add or update ADR files identified during the ADR assessment, keeping them separate from implementation details.
+   - Add or update wiki pages identified during the wiki assessment in the wiki repository, not in the main repository PR.
    - If `version` is known and the change is release-worthy, update version references together.
    - If `version` is pending, leave existing released version references unchanged during implementation and note the deferred version bump in the issue and PR.
    - For pvkgadgets version bumps, update at least:
@@ -134,7 +175,7 @@ Closes #<issue-number>
    - Update npm `exports`, package `files`, type declarations, and workflow metadata when the release changes npm package shape.
    - Keep generated UI behavior consistent with the existing app style.
 
-5. Verify Locally
+7. Verify Locally
    - Run the available local checks for this Vite/TypeScript app:
 
      ```sh
@@ -144,30 +185,32 @@ Closes #<issue-number>
      ```
 
    - Use the existing VS Code task `Start pvkgadgets server` or run `npm run dev` when browser verification is needed.
+   - For wiki changes, preview with Gollum and verify affected pages, sidebar links, images, and favicon assets.
    - Use browser automation when practical to verify critical UI behavior.
    - Stop any verification server you started when done.
 
-6. Commit and Push
+8. Commit and Push
    - Review the diff and error list before committing.
    - Commit focused changes with a concise message.
    - Push the branch to `origin`.
+   - If wiki changes were made, commit them separately in `/workspaces/pvkgadgets.wiki` and push `master` only after the user confirms publication.
 
-7. Open Pull Request
+9. Open Pull Request
    - Create a non-draft PR targeting `main` unless the user asks for a draft.
-   - Include a concise summary, notable implementation details, verification commands and manual checks, release notes draft, and `Fixes #<issue-number>`.
+   - Include a concise summary, notable implementation details, ADR added/updated/referenced if applicable, wiki changes or wiki publication status if applicable, verification commands and manual checks, release notes draft, and `Fixes #<issue-number>`.
    - Report the PR URL.
 
-8. Wait for User Confirmation
+10. Wait for User Confirmation
    - Ask the user to confirm their own manual check before merge/release.
    - If `version` is pending, ask the user to choose the final release version before continuing to merge/release steps that require version metadata.
    - When they explicitly say to proceed, continue.
 
-9. Merge PR
+11. Merge PR
    - Re-check PR status, review requirements, and local working tree.
    - Merge using the repository's preferred style. If no preference is known, use squash merge.
    - Confirm the issue closes automatically or report if it does not.
 
-10. Tag, Release, and Publish
+12. Tag, Release, and Publish
     - Switch to `main`, fetch, and fast-forward pull.
       - If `version` is pending, stop and ask for the final version before changing files, tagging, or publishing a release.
       - Once the final version is chosen, normalize it to both `X.Y.Z` and `vX.Y.Z` forms and check that the tag does not already exist.
@@ -186,16 +229,17 @@ Closes #<issue-number>
     - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
     - After publication, verify `npm view @pkistudio/pvkgadgets@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and import the package entry points.
 
-11. Confirm Final State
-    - Verify:
-      - PR is merged and closed.
-      - issue is closed as completed.
-      - tag exists on `main` HEAD.
-      - GitHub Release is published.
-      - npm package version is published and has the expected dist-tag.
-      - GitHub Pages deployment from `.github/workflows/pages.yml` completed, failed, or is clearly reported as pending.
-      - relevant GitHub Actions completed or are still running.
-    - Final response must include issue, PR, release, tag, npm, Pages, and Actions status.
+13. Confirm Final State
+      - Verify:
+         - PR is merged and closed.
+         - issue is closed as completed.
+         - tag exists on `main` HEAD.
+         - GitHub Release is published.
+         - npm package version is published and has the expected dist-tag.
+         - wiki changes are pushed, intentionally deferred, or not applicable.
+         - GitHub Pages deployment from `.github/workflows/pages.yml` completed, failed, or is clearly reported as pending.
+         - relevant GitHub Actions completed or are still running.
+      - Final response must include issue, PR, release, tag, npm, wiki, Pages, and Actions status.
 
 ## Final Response Format
 
@@ -205,6 +249,7 @@ Keep the final response concise and include:
 - PR link and merge state
 - Release link and tag
 - npm package/version status
+- Wiki publication status, if applicable
 - Pages URL and deployment status
 - Verification summary
 - Actions status

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,6 +17,13 @@
           "endsPattern": "Local:.*http://localhost:5173/"
         }
       }
+    },
+    {
+      "label": "Start pvkgadgets wiki",
+      "type": "shell",
+      "command": "gollum --host 0.0.0.0 --port 4567 /workspaces/pvkgadgets.wiki",
+      "isBackground": true,
+      "problemMatcher": []
     }
   ]
 }

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,25 @@
+# ADR-0000: Title
+
+## Status
+
+Proposed / Accepted / Deprecated / Superseded
+
+## Context
+
+Describe the background and situation that made this decision necessary.
+
+## Decision
+
+Describe the decision that was made.
+
+## Alternatives
+
+List the alternatives that were considered.
+
+## Consequences
+
+Describe the positive effects, negative effects, and future constraints caused by this decision.
+
+## Related
+
+List related issues, pull requests, documents, or existing ADRs.


### PR DESCRIPTION
Summary:
- Add devcontainer and VS Code task support for local Gollum wiki maintenance.
- Add ADR instruction/template files for docs/adr.
- Update the release prompt with ADR assessment and wiki maintenance guidance.

Verification:
- `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json','utf8')); JSON.parse(require('fs').readFileSync('.vscode/tasks.json','utf8')); console.log('json ok')"`
- `bash -n .devcontainer/setup-wiki.sh`
- `git diff --check`
- `npm run check`
- `npm run build`

Release:
- No release artifact, tag, GitHub Release, or npm publication for this maintenance change.