### PR TITLE
Add hosted viewer link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Private Key Gadgets is an experimental browser tool and reusable TypeScript API for generating, importing, exporting, and inspecting PKI key material. It keeps key-related objects in a PkiStudioJS-style tree and displays selected DER objects with the embedded PkiStudioJS ASN.1 viewer.
 
+Hosted viewer: https://pkistudio.github.io/pvkgadgets/
+
 Documentation: https://github.com/pkistudio/pvkgadgets/wiki
 
 Current version: 0.4.2


### PR DESCRIPTION
Summary:
- Add the GitHub Pages hosted viewer URL near the top of the README.

Verification:
- `git diff --check`
- `npm run pack:dry-run`

Release:
- No release artifact, tag, GitHub Release, or npm publication for this documentation-only change.