### PR TITLE
chore: bootstrap managed rules sync

### DIFF
--- a/.github/instructions/adr.instructions.md
+++ b/.github/instructions/adr.instructions.md
@@ -1,21 +1,23 @@
 ---
-applyTo: "docs/adr/**/*.md"
+description: "Use when reviewing code against Architecture Decision Records or deciding whether to create ADRs for PkiStudio repositories."
+name: "PkiStudio ADR Rules"
 ---
 
-When writing an ADR, record only one architectural decision per file.
+# PkiStudio ADR Rules
 
-Focus on why the decision was made, not on implementation steps.
-
-Each ADR must include the following sections:
-
-- Status
-- Context
-- Decision
-- Alternatives
-- Consequences
-
-If an existing ADR is replaced by a new decision, do not delete the old ADR. Mark the old ADR as `Superseded` and keep a reference to the new ADR.
-
-Use clear and concise language. Avoid long explanations unless they are necessary to understand the decision.
-
-When possible, include links to related issues, pull requests, design notes, or other ADRs.
+- Create an ADR only for a meaningfully architectural decision, a long-lived trade-off, or an explicit user request.
+- Do not create ADRs for routine implementation details, dependency bumps, small refactors, copy changes, or release mechanics.
+- Keep ADR work in the current repository unless the user explicitly asks for cross-repository coordination.
+- Prefer `docs/adr/` unless the repository profile names another ADR location.
+- When reviewing code, check whether proposed changes are consistent with existing ADRs under `docs/adr/` or the repository's configured ADR location.
+- Pay special attention to changes involving external dependencies, database selection or schema strategy, authentication and authorization, API design, cryptographic algorithms or key management, deployment architecture, runtime infrastructure, and major framework or library choices.
+- If a change appears to conflict with an existing ADR, point out the relevant ADR and explain the conflict.
+- If a pull request introduces an important architectural decision without an ADR, suggest adding a new ADR under `docs/adr/` or the repository's configured ADR location.
+- When suggesting an ADR, recommend using the existing ADR template at `docs/adr/0000-template.md` when available.
+- Use a short, durable title that names the decision, not the implementation task.
+- Include context, decision, consequences, alternatives considered, rollout or migration notes, and related issue or PR links when available.
+- Mark status clearly, such as `Proposed`, `Accepted`, `Superseded`, or `Rejected`.
+- If an ADR supersedes an older ADR, update both documents so the relationship is discoverable.
+- Keep ADRs concise and factual. Record the decision and reasoning, not a full project history.
+- Do not treat ADRs as implementation manuals. ADRs should explain why a decision was made, what alternatives were considered, and what consequences are expected.
+- Prefer concise, actionable review comments.

--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -1,0 +1,17 @@
+---
+description: "Use when preparing, verifying, approving, or publishing releases for PkiStudio repositories."
+name: "PkiStudio Release Rules"
+---
+
+# PkiStudio Release Rules
+
+- Read `.github/release-profile.md` before taking release-related action.
+- Use the profile as the source of truth for product name, package name, version files, build commands, Pages artifact paths, Wiki paths, and repository-specific release hooks.
+- Work from an issue and feature branch for implementation work. Do not implement directly on `main`.
+- Never discard user changes or overwrite local work without explicit approval.
+- Run the repository's local verification commands before opening or updating a release PR.
+- Do not merge, tag, publish npm packages, create public GitHub Releases, post to WordPress, or modify Wiki content without explicit approval for that step.
+- Keep Wiki edits separate from main repository changes unless the user explicitly asks to combine planning context.
+- Treat version bumps, changelog updates, tags, GitHub Releases, npm publish, WordPress posts, Pages checks, and Actions verification as separate release checkpoints.
+- If verification fails, stop and report the failing command, relevant output, and the next recommended fix.
+- Do not create an ADR for a release unless the release includes a meaningful architectural decision or the user requests one.

--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -1,256 +1,36 @@
 ---
-description: "Use when: running the pvkgadgets issue-to-release workflow, including issue creation, ADR assessment, wiki maintenance, branch work, PR, merge, tag, GitHub Release, npm publish, Trusted Publishing, GitHub Pages status, and Actions checks."
-name: "pvkgadgets release workflow"
-argument-hint: "[version|TBD] [#issue] <short feature or fix summary>"
+description: "Run the standard PkiStudio release workflow for a repository."
+name: "PkiStudio Standard Release Workflow"
 agent: "agent"
 ---
 
-# pvkgadgets Release Workflow
+# PkiStudio Standard Release Workflow
 
-Run the standard pvkgadgets release workflow from issue creation through GitHub Release, npm publication, and GitHub Pages status confirmation.
-
-Expected invocation examples:
-
-```text
-/release 0.3.1 "Improve PKCS#12 import"
-/release v0.3.1 "Fix certificate matching"
-/release TBD "Improve CSR generation"
-/release "Improve API log output"
-/release TBD #12
-/release 0.3.2 #12 "Implement requested export option"
-```
-
-The release version may be omitted or set to `TBD` when development should proceed before the final version is known. If an existing issue number is supplied, use that issue instead of creating a duplicate issue. If the feature summary, desired release scope, issue reference, or whether a known-looking first argument is a version is unclear, ask concise clarifying questions before making changes. Otherwise proceed proactively.
+Run the standard PkiStudio release workflow.
 
 ## Default Operating Mode
 
-When this prompt is invoked, proceed through the workflow without restating the full release procedure to the user. Treat the issue-to-release flow as the standard path and keep progress updates brief.
-
-Default assumptions:
-
-- If no issue number is supplied, create a tracking issue first.
-- If an issue number is supplied, use that issue as the source of truth.
-- Create a branch from the issue, implement the requested change, verify it, push it, and open a PR.
-- Assess whether issue-level architectural decisions should be captured in ADRs under `docs/adr/`; ask the user only when you judge that a new ADR may be warranted and the user has not already requested or declined one.
-- Assess whether user-facing behavior, package API behavior, release process expectations, or operating procedures should be reflected in the GitHub Wiki, and keep wiki work separate from the main repository PR.
-- Use the issue body, issue comments, and PR body to preserve the release rationale, release notes draft, verification results, and publication status.
-- Do not merge, tag, publish, or create a GitHub Release until the user explicitly says to proceed.
-
-Ask only when:
-
-- The requested version is missing and the workflow has reached a version-required step.
-- The issue appears to introduce a meaningful ADR-worthy architectural decision and the user has not already requested or declined ADR creation.
-- The working tree has unrelated uncommitted changes.
-- npm or GitHub permissions block progress.
-- The issue requirements are ambiguous enough that implementation could go in the wrong direction.
-
-Confirmation gates:
-
-- Gate 1: PR merge.
-- Gate 2: version bump, tag push, GitHub Release creation, and the automatic npm publish trigger caused by the tag.
-- Gate 3: npm publish workflow rerun or manual npm publication if the tag-triggered publish needs intervention.
-- Gate 4: post-publication registry, fresh-install, Pages, and Actions verification.
+- Create or use a GitHub issue.
+- Create a feature branch.
+- Implement the requested change.
+- Run local verification.
+- Open a PR.
+- Wait for user approval before merging.
+- After merge approval, prepare version bump, tag, GitHub Release, npm publish, WordPress post, Pages verification, and Actions verification.
 
 ## Required Safety Rules
 
-- This prompt is a workflow guide only and does not grant repository permissions.
-- Push, tag, release, merge, and secret-backed Actions operations are possible only for users or tokens with the required repository permissions.
-- npm publication requires npm package ownership or a configured npm Trusted Publisher for `@pkistudio/pvkgadgets` and `.github/workflows/publish-npm.yml`.
-- Work in the current repository only.
-- Check the current branch, remote, and working tree before making changes.
-- Never discard uncommitted user changes.
-- If unrelated local changes exist, stop and ask how to proceed.
-- Create implementation work on a feature branch, never directly on `main`.
-- Use existing repository patterns and keep changes focused on the requested issue.
-- Do not create ADRs for trivial implementation details, routine bug fixes, or decisions already covered by an existing ADR.
-- When adding or updating ADRs, use `docs/adr/0000-template.md` and keep the ADR focused on why the decision was made, alternatives considered, and expected consequences.
-- Do not add a new ADR solely on agent judgment without user confirmation, unless the user explicitly requested ADR creation in the invocation or issue discussion.
-- Keep GitHub Wiki work in the wiki repository, normally `/workspaces/pvkgadgets.wiki`, and do not mix wiki commits into the main repository PR.
-- Do not push wiki changes until the user has asked for publication or confirmed the prepared wiki content.
-- Preserve existing `package.json` package metadata unless the release requires a focused change. Do not add `private: true` only to prevent npm publication.
-- Use non-interactive git commands.
+- Work only in the current repository.
+- Never discard user changes.
+- Never work directly on main for implementation work.
+- Do not publish npm or create public GitHub Releases without explicit approval.
+- Do not create ADRs unless the change is meaningfully architectural or the user requested one.
+- Keep Wiki work separate from the main repository.
 
-## Inputs
+## Repository Profile
 
-Derive these from the invocation when possible:
+Before acting, read the repository-specific profile from:
 
-- `version`: release version, normalized to both `X.Y.Z` and `vX.Y.Z` forms when known. If omitted or `TBD`, treat it as pending and do not create tags, publish releases, or make final version bumps until the release step.
-- `issueNumber`: existing GitHub issue number when the invocation includes a `#<number>` reference or an unambiguous issue URL.
-- `summary`: short feature or fix summary.
-- `issueBody`: issue requirements. If the user supplied detailed requirements, preserve them.
-- `architectureDecision`: issue-level design decision, if the issue includes one that should be recorded in `docs/adr/`.
-- `wikiWork`: user-facing documentation or operating procedure updates that should be reflected in the GitHub Wiki.
-- `verificationPlan`: expected local checks. If not supplied, infer from the changed area.
+.github/release-profile.md
 
-## Standard Record Templates
-
-Use these headings for new release tracking issues unless the issue already has a better structure:
-
-```md
-## Background
-## Scope
-## Release notes draft
-## Verification
-## Publication status
-```
-
-Use this shape for PR bodies:
-
-```md
-Summary:
-- ...
-
-ADR:
-- Added/updated/referenced: ...
-
-Wiki:
-- Added/updated/pushed: ...
-
-Release notes draft:
-...
-
-Verification:
-- `npm run check`
-- `npm run build`
-- `npm run pack:dry-run`
-
-Closes #<issue-number>
-```
-
-## Workflow
-
-1. Preflight
-   - Confirm the repository is `pkistudio/pvkgadgets` unless the user intentionally targets another repo.
-   - Run a clean working tree check.
-   - Confirm the current default branch and remote.
-   - If `version` is known, check existing tags so the requested release version does not already exist.
-   - If `version` is known, check whether `@pkistudio/pvkgadgets@<version>` is already published on npm so reruns do not attempt to publish an immutable version twice.
-   - If `version` is pending, record that the final version must be chosen before version bumps, tagging, or release publication.
-
-2. Create Issue
-   - If `issueNumber` is known, fetch the existing issue and use its title, body, requirements, labels, and discussion as the source request. Do not create a new issue.
-   - If no existing issue is supplied, create a GitHub issue describing the requested change.
-   - For new issues, include summary, requirements, expected behavior, and verification notes.
-   - Record the issue number for the branch, PR body, and final report.
-   - Prefer GitHub tools when available. If the GitHub CLI is unavailable and `GITHUB_TOKEN` is set, use the GitHub REST API with `curl`. Never print token values.
-
-3. Assess ADR Needs
-   - Review `docs/adr/` before implementation when the issue involves external dependencies, package export strategy, public API design, cryptographic algorithms or key management, PKCS#12 handling, certificate or CSR semantics, host integration boundaries, deployment architecture, runtime infrastructure, or major framework or library choices.
-   - Ask the user about ADR creation only when you judge that the issue introduces a meaningful architectural decision that is not already covered by an existing ADR.
-   - Do not ask about ADRs for routine fixes, implementation details, local refactors, documentation-only changes, release bookkeeping, or decisions already covered by an existing ADR.
-   - If the user already requested ADR creation, proceed with the ADR without asking again.
-   - If the user already declined ADR creation for the issue, continue without asking again.
-   - When asking, briefly explain the suspected decision, why it may deserve an ADR, and the proposed ADR title. Keep the question concise and offer a clear yes/no path.
-   - If the user confirms, add a new ADR under `docs/adr/` using `docs/adr/0000-template.md`.
-   - If the user declines, continue without an ADR and mention the decision in the PR body when useful.
-   - Number new ADRs sequentially and use a concise kebab-case filename such as `0001-keep-host-neutral-browser-api.md`.
-   - In the ADR, reference the source issue and any related ADRs in the `Related` section.
-   - If the implementation follows an existing ADR, mention that ADR in the PR body instead of creating a duplicate ADR.
-   - If the issue appears to conflict with an existing ADR, stop and ask how to proceed before implementing the conflicting change.
-
-4. Assess Wiki Needs
-   - Use the GitHub Wiki for user-facing operational guidance, reusable API guidance, release process notes, screenshots, and documentation that should be browsed outside the package README.
-   - Keep README updates in the main repository when they describe package installation, package exports, current version, or npm-facing documentation. Use the wiki for expanded workflows and maintenance guidance.
-   - If wiki changes are needed, work in `/workspaces/pvkgadgets.wiki` when it exists. If it is missing, run `.devcontainer/setup-wiki.sh` or clone `https://github.com/pkistudio/pvkgadgets.wiki.git` next to the main workspace.
-   - Follow the existing wiki structure and PkiStudioJS-style conventions: Markdown pages at the wiki root, `_Sidebar.md` for navigation, `images/` for screenshots, and root `favicon.ico` for the wiki favicon.
-   - Validate wiki links and image references before committing. For Gollum preview, use the VS Code task `Start pvkgadgets wiki` or run `gollum --host 0.0.0.0 --port 4567 /workspaces/pvkgadgets.wiki`; if port `4567` is already in use, use a temporary alternate port and stop it when done.
-   - Commit wiki changes in the wiki repository separately from the main repository implementation branch.
-   - Push wiki changes only after the user has asked for publication or confirmed the prepared wiki content. Record pushed wiki commit hashes in the issue or final report when relevant.
-
-5. Create Branch
-   - Create a branch named `issue-<number>-<short-kebab-summary>`.
-   - Switch to it before editing files.
-
-6. Implement
-   - Read the relevant files before editing.
-   - Update app code and documentation for the requested behavior.
-   - Add or update ADR files identified during the ADR assessment, keeping them separate from implementation details.
-   - Add or update wiki pages identified during the wiki assessment in the wiki repository, not in the main repository PR.
-   - If `version` is known and the change is release-worthy, update version references together.
-   - If `version` is pending, leave existing released version references unchanged during implementation and note the deferred version bump in the issue and PR.
-   - For pvkgadgets version bumps, update at least:
-     - `package.json` `version`, which is the source for the app and `window.PvkGadgetsCore.version`
-     - `package-lock.json` root package version
-     - `README.md` current version and any relevant feature documentation
-   - Update npm `exports`, package `files`, type declarations, and workflow metadata when the release changes npm package shape.
-   - Keep generated UI behavior consistent with the existing app style.
-
-7. Verify Locally
-   - Run the available local checks for this Vite/TypeScript app:
-
-     ```sh
-     npm run check
-     npm run build
-     npm run pack:dry-run
-     ```
-
-   - Use the existing VS Code task `Start pvkgadgets server` or run `npm run dev` when browser verification is needed.
-   - For wiki changes, preview with Gollum and verify affected pages, sidebar links, images, and favicon assets.
-   - Use browser automation when practical to verify critical UI behavior.
-   - Stop any verification server you started when done.
-
-8. Commit and Push
-   - Review the diff and error list before committing.
-   - Commit focused changes with a concise message.
-   - Push the branch to `origin`.
-   - If wiki changes were made, commit them separately in `/workspaces/pvkgadgets.wiki` and push `master` only after the user confirms publication.
-
-9. Open Pull Request
-   - Create a non-draft PR targeting `main` unless the user asks for a draft.
-   - Include a concise summary, notable implementation details, ADR added/updated/referenced if applicable, wiki changes or wiki publication status if applicable, verification commands and manual checks, release notes draft, and `Fixes #<issue-number>`.
-   - Report the PR URL.
-
-10. Wait for User Confirmation
-   - Ask the user to confirm their own manual check before merge/release.
-   - If `version` is pending, ask the user to choose the final release version before continuing to merge/release steps that require version metadata.
-   - When they explicitly say to proceed, continue.
-
-11. Merge PR
-   - Re-check PR status, review requirements, and local working tree.
-   - Merge using the repository's preferred style. If no preference is known, use squash merge.
-   - Confirm the issue closes automatically or report if it does not.
-
-12. Tag, Release, and Publish
-    - Switch to `main`, fetch, and fast-forward pull.
-      - If `version` is pending, stop and ask for the final version before changing files, tagging, or publishing a release.
-      - Once the final version is chosen, normalize it to both `X.Y.Z` and `vX.Y.Z` forms and check that the tag does not already exist.
-      - If version references were deferred, create a focused version bump commit on `main` or on a release-prep branch/PR if the user wants review before publication.
-    - Create an annotated tag `vX.Y.Z` on the merged `main` commit and push it only after the user has approved Gate 2.
-      - The `Publish npm package` workflow runs on `v*` tag pushes and publishes with npm Trusted Publishing. It expects:
-        - npm package name: `@pkistudio/pvkgadgets`
-        - GitHub owner/repository: `pkistudio/pvkgadgets`
-        - workflow filename: `publish-npm.yml`
-        - npm Trusted Publishing environment: none / blank, unless the workflow is later changed to use one.
-      - For scoped npm packages, `E404` during publish can mean the package does not exist yet or the workflow/account lacks scope permission.
-      - If npm publish fails with `E404` or `no permission`, explain that npm Trusted Publishing or initial package ownership is not configured. Do not keep rerunning the same job until npm permissions are fixed.
-      - Do not create a new tag just to retry npm publication when the version and tag are already correct. After fixing npm permissions or Trusted Publishing, rerun the failed publish workflow or publish manually from an authorized npm account.
-      - If the version was already published manually, do not rerun the publish job for the same tag/version; npm versions are immutable and the rerun will fail.
-    - Create a GitHub Release named `vX.Y.Z` with release notes summarizing user-facing changes and referencing the issue.
-    - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
-    - After publication, verify `npm view @pkistudio/pvkgadgets@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and import the package entry points.
-
-13. Confirm Final State
-      - Verify:
-         - PR is merged and closed.
-         - issue is closed as completed.
-         - tag exists on `main` HEAD.
-         - GitHub Release is published.
-         - npm package version is published and has the expected dist-tag.
-         - wiki changes are pushed, intentionally deferred, or not applicable.
-         - GitHub Pages deployment from `.github/workflows/pages.yml` completed, failed, or is clearly reported as pending.
-         - relevant GitHub Actions completed or are still running.
-      - Final response must include issue, PR, release, tag, npm, wiki, Pages, and Actions status.
-
-## Final Response Format
-
-Keep the final response concise and include:
-
-- Issue link and state
-- PR link and merge state
-- Release link and tag
-- npm package/version status
-- Wiki publication status, if applicable
-- Pages URL and deployment status
-- Verification summary
-- Actions status
-- Any follow-up needed
+Use that file for product name, npm package name, version files, build commands, Pages artifact path, Wiki path, and special release hooks.

--- a/.github/release-profile.md
+++ b/.github/release-profile.md
@@ -1,0 +1,49 @@
+# pvkgadgets Release Profile
+
+## Repository
+
+- GitHub repository: `pkistudio/pvkgadgets`
+- Product name: `Private Key Gadgets`
+- npm package name: `@pkistudio/pvkgadgets`
+- Hosted Pages URL: `https://pkistudio.github.io/pvkgadgets/`
+- Documentation URL: `https://github.com/pkistudio/pvkgadgets/wiki`
+- ADR path: `docs/adr/`
+
+## Version And Build
+
+- Version files:
+  - `package.json`
+  - `package-lock.json`
+  - `README.md` (`Current version:`)
+- Version source: `package.json` version is injected into `__PVKGADGETS_VERSION__`, the app About display, and `PvkGadgetsCore.version`.
+- Install command: `npm ci`
+- Build command: `npm run build`
+- Verification commands:
+  - `npm run check`
+  - `npm run build`
+- Package preview command: `npm run pack:dry-run`
+- Published package verification:
+  - `npm view @pkistudio/pvkgadgets@<version> version dist-tags dist.tarball --json`
+
+## Publishing
+
+- npm publish workflow: `.github/workflows/publish-npm.yml`
+- npm publish command in workflow: `npm publish --provenance --access public`
+- npm publication requires explicit user approval.
+- GitHub Release requires explicit user approval.
+- Stable published tags should have a GitHub Release marked as latest unless the user instructs otherwise.
+- WordPress post workflow: `.github/workflows/publish-release-to-wordpress.yml`
+- WordPress post title pattern: `Private Key Gadgets <tag> をリリースしました`
+
+## Pages And Wiki
+
+- Pages workflow: `.github/workflows/pages.yml`
+- Pages artifact path: `dist`
+- Wiki path in Codespaces: `/workspaces/pvkgadgets.wiki`
+- Keep Wiki work separate from main repository work unless explicitly requested.
+
+## Special Hooks
+
+- Keep the package browser-first and host-neutral. VS Code-specific file access, dialogs, and Webview lifecycle belong outside this package.
+- Updating `@pkistudio/pkistudiojs` for viewer compatibility is normally a dependency and documentation update, not a Private Key Gadgets feature change.
+- Browser verification command: `npm run dev -- --port 5173 --strictPort`.

--- a/.github/workflows/sync-managed-rules.yml
+++ b/.github/workflows/sync-managed-rules.yml
@@ -1,0 +1,40 @@
+name: Sync managed rules
+
+on:
+  workflow_dispatch:
+    inputs:
+      managedrules_ref:
+        description: managedrules ref to sync from
+        required: false
+        default: main
+  schedule:
+    - cron: "23 3 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout product repository
+        uses: actions/checkout@v4
+        with:
+          path: target
+          fetch-depth: 0
+
+      - name: Checkout managed rules
+        uses: actions/checkout@v4
+        with:
+          repository: pkistudio/managedrules
+          ref: ${{ inputs.managedrules_ref || 'main' }}
+          path: managedrules
+
+      - name: Sync managed rules
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node managedrules/scripts/sync-managed-rules.mjs \
+            --manifest "managedrules/manifests/${{ github.event.repository.name }}.yml" \
+            --target-dir target


### PR DESCRIPTION
Summary:
- Add the managed rules sync workflow from `pkistudio/managedrules`.
- Sync the managed release prompt and ADR instructions.
- Add the shared release instructions and pvkgadgets release profile.

Verification:
- `node scripts/sync-managed-rules.mjs --manifest manifests/pvkgadgets.yml --target-dir /workspaces/pvkgadgets --dry-run` from `pkistudio/managedrules` reports no managed rule changes.
- `git diff --check`
- `npm run check`
- `npm run build`